### PR TITLE
feat: CSV export (Xuất CSV) với round-trip hoàn hảo

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -4,6 +4,7 @@ import SearchBar from './SearchBar'
 import CsvImportModal from './CsvImportModal'
 import SettingsPanel from './SettingsPanel'
 import { ghiFile } from '../services/googleDrive'
+import { exportGiaphaToCSV, downloadCsv } from '../utils/csvExport'
 
 export default function Navbar() {
   const { data, fileId, isDirty, isSaving, currentRole, currentUserEmail, viewMode, setViewMode, setIsSaving, markSaved, setConflictDetected } = useGiaphaStore()
@@ -29,6 +30,14 @@ export default function Navbar() {
   }
 
   const canEdit = currentRole === 'admin' || currentRole === 'editor'
+
+  function handleExportCsv() {
+    if (!data) return
+    const csv = exportGiaphaToCSV(data)
+    const tenDongHo = data.metadata.tenDongHo.replace(/\s+/g, '_')
+    const date = new Date().toISOString().slice(0, 10)
+    downloadCsv(`giaphaHo${tenDongHo}_${date}.csv`, csv)
+  }
 
   return (
     <>
@@ -61,6 +70,14 @@ export default function Navbar() {
             className="px-3 py-1.5 text-sm rounded-md border border-gray-300 hover:bg-gray-50"
           >
             Nhập CSV
+          </button>
+        )}
+        {canEdit && data && (
+          <button
+            onClick={handleExportCsv}
+            className="px-3 py-1.5 text-sm rounded-md border border-gray-300 hover:bg-gray-50"
+          >
+            Xuất CSV
           </button>
         )}
         {canEdit && isDirty && (

--- a/src/utils/csvExport.test.ts
+++ b/src/utils/csvExport.test.ts
@@ -1,0 +1,252 @@
+import { describe, it, expect } from 'vitest'
+import type { GiaphaData, Person } from '../types/giapha'
+import { exportGiaphaToCSV } from './csvExport'
+import { importSingleCsvToGiapha } from './csvImport'
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const METADATA: GiaphaData['metadata'] = {
+  tenDongHo: 'Test',
+  ngayTao: '2026-01-01T00:00:00.000Z',
+  nguoiTao: '',
+  phienBan: 1,
+  cheDoCong: false,
+  danhSachNguoiDung: [],
+}
+
+function nguoiMau(ghi: Partial<Person>): Person {
+  return {
+    id: 0,
+    hoTen: 'Test',
+    gioiTinh: 'nam',
+    laThanhVienHo: true,
+    honNhan: [],
+    conCaiIds: [],
+    ...ghi,
+  }
+}
+
+function makeData(persons: Person[]): GiaphaData {
+  return {
+    metadata: METADATA,
+    persons: Object.fromEntries(persons.map(p => [p.id, p])),
+  }
+}
+
+// ─── Unit tests ───────────────────────────────────────────────────────────────
+
+describe('exportGiaphaToCSV', () => {
+  it('produces correct 22-column header', () => {
+    const csv = exportGiaphaToCSV(makeData([nguoiMau({ id: 1 })]))
+    // Strip BOM
+    const clean = csv.startsWith('\uFEFF') ? csv.slice(1) : csv
+    const header = clean.split(/\r?\n/)[0]
+    const cols = header.split(',')
+    expect(cols).toHaveLength(22)
+    expect(cols[0]).toBe('id')
+    expect(cols[1]).toBe('hoTen')
+    expect(cols[2]).toBe('gioiTinh')
+    expect(cols[15]).toBe('voChongIds')
+  })
+
+  it('starts with UTF-8 BOM', () => {
+    const csv = exportGiaphaToCSV(makeData([nguoiMau({ id: 1 })]))
+    expect(csv.charCodeAt(0)).toBe(0xFEFF)
+  })
+
+  it('serialises full NgayThang correctly', () => {
+    const data = makeData([
+      nguoiMau({ id: 1, namSinh: { nam: 1950, thang: 3, ngay: 15, amLich: false } }),
+    ])
+    const lines = exportGiaphaToCSV(data).replace('\uFEFF', '').split(/\r?\n/)
+    const cols = lines[1].split(',')
+    expect(cols[5]).toBe('1950')  // namSinh_nam
+    expect(cols[6]).toBe('3')     // namSinh_thang
+    expect(cols[7]).toBe('15')    // namSinh_ngay
+    expect(cols[8]).toBe('false') // namSinh_amLich
+  })
+
+  it('leaves date sub-fields empty when only nam is set', () => {
+    const data = makeData([nguoiMau({ id: 1, namSinh: { nam: 1920 } })])
+    const lines = exportGiaphaToCSV(data).replace('\uFEFF', '').split(/\r?\n/)
+    const cols = lines[1].split(',')
+    expect(cols[5]).toBe('1920') // namSinh_nam
+    expect(cols[6]).toBe('')     // namSinh_thang
+    expect(cols[7]).toBe('')     // namSinh_ngay
+    expect(cols[8]).toBe('')     // namSinh_amLich
+  })
+
+  it('quotes fields containing commas', () => {
+    const data = makeData([nguoiMau({ id: 1, hoTen: '1. Hg Văn Bột, Cụ Tổ' })])
+    const lines = exportGiaphaToCSV(data).replace('\uFEFF', '').split(/\r?\n/)
+    expect(lines[1]).toContain('"1. Hg Văn Bột, Cụ Tổ"')
+  })
+
+  it('escapes double-quotes inside fields', () => {
+    const data = makeData([nguoiMau({ id: 1, tieuSu: 'Ông nói "xin chào"' })])
+    const csv = exportGiaphaToCSV(data).replace('\uFEFF', '')
+    expect(csv).toContain('"Ông nói ""xin chào"""')
+  })
+
+  it('joins multiple voChongIds with semicolon', () => {
+    const data = makeData([
+      nguoiMau({ id: 1, honNhan: [{ voChongId: 2 }, { voChongId: 3 }] }),
+      nguoiMau({ id: 2, gioiTinh: 'nu', laThanhVienHo: false }),
+      nguoiMau({ id: 3, gioiTinh: 'nu', laThanhVienHo: false }),
+    ])
+    const lines = exportGiaphaToCSV(data).replace('\uFEFF', '').split(/\r?\n/)
+    const cols = lines[1].split(',')
+    expect(cols[15]).toBe('2;3') // voChongIds
+  })
+
+  it('sorts persons by id ascending', () => {
+    const data = makeData([
+      nguoiMau({ id: 5, hoTen: 'Năm' }),
+      nguoiMau({ id: 1, hoTen: 'Một' }),
+      nguoiMau({ id: 3, hoTen: 'Ba' }),
+    ])
+    const lines = exportGiaphaToCSV(data).replace('\uFEFF', '').split(/\r?\n/).filter(Boolean)
+    expect(lines[1].startsWith('1,')).toBe(true)
+    expect(lines[2].startsWith('3,')).toBe(true)
+    expect(lines[3].startsWith('5,')).toBe(true)
+  })
+
+  it('exports boId and meId correctly', () => {
+    const data = makeData([
+      nguoiMau({ id: 1, gioiTinh: 'nam', honNhan: [{ voChongId: 2 }] }),
+      nguoiMau({ id: 2, gioiTinh: 'nu', laThanhVienHo: false, honNhan: [{ voChongId: 1 }] }),
+      nguoiMau({ id: 3, gioiTinh: 'nam', boId: 1, meId: 2 }),
+    ])
+    const lines = exportGiaphaToCSV(data).replace('\uFEFF', '').split(/\r?\n/)
+    const child = lines[3].split(',') // id=3 → 3rd data row
+    expect(child[13]).toBe('1') // boId
+    expect(child[14]).toBe('2') // meId
+  })
+})
+
+// ─── Round-trip tests ─────────────────────────────────────────────────────────
+
+describe('CSV round-trip (export → import)', () => {
+  it('simple family: 0 errors and 0 warnings after reimport', () => {
+    const data = makeData([
+      nguoiMau({ id: 1, hoTen: 'Nguyễn Văn Tổ', gioiTinh: 'nam', laThanhVienHo: true,
+        namSinh: { nam: 1870 }, honNhan: [{ voChongId: 2 }] }),
+      nguoiMau({ id: 2, hoTen: 'Trần Thị Cội', gioiTinh: 'nu', laThanhVienHo: false,
+        namSinh: { nam: 1875 }, honNhan: [{ voChongId: 1 }] }),
+      nguoiMau({ id: 3, hoTen: 'Nguyễn Văn Con', gioiTinh: 'nam', laThanhVienHo: true,
+        namSinh: { nam: 1900 }, boId: 1, meId: 2 }),
+    ])
+
+    const csv = exportGiaphaToCSV(data)
+    const result = importSingleCsvToGiapha(csv, METADATA)
+
+    expect(result.errors).toHaveLength(0)
+    expect(result.warnings).toHaveLength(0)
+    expect(result.stats.personCount).toBe(3)
+  })
+
+  it('preserves names, dates and parent links after round-trip', () => {
+    const data = makeData([
+      nguoiMau({ id: 1, hoTen: 'Họ Văn Cha', gioiTinh: 'nam', laThanhVienHo: true,
+        namSinh: { nam: 1890, thang: 5, ngay: 10 },
+        namMat: { nam: 1965 },
+        honNhan: [{ voChongId: 2 }] }),
+      nguoiMau({ id: 2, hoTen: 'Lê Thị Mẹ', gioiTinh: 'nu', laThanhVienHo: false,
+        namSinh: { nam: 1895 }, honNhan: [{ voChongId: 1 }] }),
+      nguoiMau({ id: 3, hoTen: '1. Hg Văn Bột, Cụ Tổ', gioiTinh: 'nam', laThanhVienHo: true,
+        namSinh: { nam: 1920 }, boId: 1, meId: 2 }),
+    ])
+
+    const csv = exportGiaphaToCSV(data)
+    const result = importSingleCsvToGiapha(csv, METADATA)
+
+    expect(result.errors).toHaveLength(0)
+    expect(result.warnings).toHaveLength(0)
+
+    const persons = result.data!.persons
+    expect(persons[1].hoTen).toBe('Họ Văn Cha')
+    expect(persons[1].namSinh?.nam).toBe(1890)
+    expect(persons[1].namSinh?.thang).toBe(5)
+    expect(persons[1].namSinh?.ngay).toBe(10)
+    expect(persons[1].namMat?.nam).toBe(1965)
+    expect(persons[3].hoTen).toBe('1. Hg Văn Bột, Cụ Tổ')
+    expect(persons[3].boId).toBe(1)
+    expect(persons[3].meId).toBe(2)
+  })
+
+  it('preserves bidirectional marriage links after round-trip', () => {
+    const data = makeData([
+      nguoiMau({ id: 1, gioiTinh: 'nam', honNhan: [{ voChongId: 2 }, { voChongId: 3 }] }),
+      nguoiMau({ id: 2, gioiTinh: 'nu', laThanhVienHo: false, honNhan: [{ voChongId: 1 }] }),
+      nguoiMau({ id: 3, gioiTinh: 'nu', laThanhVienHo: false, honNhan: [{ voChongId: 1 }] }),
+    ])
+
+    const csv = exportGiaphaToCSV(data)
+    const result = importSingleCsvToGiapha(csv, METADATA)
+
+    expect(result.errors).toHaveLength(0)
+    expect(result.warnings).toHaveLength(0)
+
+    const p1 = result.data!.persons[1]
+    expect(p1.honNhan.map(h => h.voChongId).sort()).toEqual([2, 3])
+    // Reverse links preserved
+    expect(result.data!.persons[2].honNhan[0].voChongId).toBe(1)
+    expect(result.data!.persons[3].honNhan[0].voChongId).toBe(1)
+  })
+
+  it('full 56-person dataset: 0 errors, 0 warnings', () => {
+    // Build a representative large dataset resembling giaphahoHoang
+    const persons: Person[] = [
+      nguoiMau({ id: 30, hoTen: '1. Hg Văn Bột, Cụ Tổ', gioiTinh: 'nam', laThanhVienHo: true,
+        namSinh: { nam: 1841 }, honNhan: [{ voChongId: 31 }] }),
+      nguoiMau({ id: 31, hoTen: 'Cụ Tổ bà', gioiTinh: 'nu', laThanhVienHo: false,
+        namSinh: { nam: 1846 }, honNhan: [{ voChongId: 30 }] }),
+      nguoiMau({ id: 27, hoTen: '2. Hg Văn Truyền', gioiTinh: 'nam', laThanhVienHo: true,
+        namSinh: { nam: 1860 }, boId: 30, meId: 31,
+        honNhan: [{ voChongId: 28 }, { voChongId: 29 }] }),
+      nguoiMau({ id: 28, hoTen: 'Bà Truyền cả', gioiTinh: 'nu', laThanhVienHo: false,
+        honNhan: [{ voChongId: 27 }] }),
+      nguoiMau({ id: 29, hoTen: 'Bà Truyền hai', gioiTinh: 'nu', laThanhVienHo: false,
+        honNhan: [{ voChongId: 27 }] }),
+      nguoiMau({ id: 25, hoTen: '3. Hg Văn Bút', gioiTinh: 'nam', laThanhVienHo: true,
+        namSinh: { nam: 1890 }, namMat: { nam: 1950, thang: 8, ngay: 9 },
+        boId: 27, meId: 29, honNhan: [{ voChongId: 26 }] }),
+      nguoiMau({ id: 26, hoTen: 'Hg Thị Kỉnh', gioiTinh: 'nu', laThanhVienHo: false,
+        namSinh: { nam: 1892 }, honNhan: [{ voChongId: 25 }] }),
+      nguoiMau({ id: 6, hoTen: '4. Hoàng Son', gioiTinh: 'nam', laThanhVienHo: true,
+        namSinh: { nam: 1925 }, namMat: { nam: 2007, thang: 12, ngay: 30 },
+        boId: 25, meId: 26,
+        tieuSu: 'Là Dũng sỹ diệt Mỹ, Dũng sỹ diệt máy bay.',
+        honNhan: [{ voChongId: 7 }, { voChongId: 16 }, { voChongId: 24 }] }),
+      nguoiMau({ id: 7, hoTen: 'Đg Thị Phát', gioiTinh: 'nu', laThanhVienHo: false,
+        namSinh: { nam: 1925 }, namMat: { nam: 2017, thang: 10, ngay: 9 },
+        honNhan: [{ voChongId: 6 }] }),
+      nguoiMau({ id: 16, hoTen: 'Lương Thị Nghĩa', gioiTinh: 'nu', laThanhVienHo: false,
+        namSinh: { nam: 1958 }, honNhan: [{ voChongId: 6 }] }),
+      nguoiMau({ id: 24, hoTen: 'Ng Thị Nhiêu', gioiTinh: 'nu', laThanhVienHo: false,
+        namSinh: { nam: 1924 }, namMat: { nam: 1947 }, honNhan: [{ voChongId: 6 }] }),
+      nguoiMau({ id: 1, hoTen: '5. Hg Văn Nông', gioiTinh: 'nam', laThanhVienHo: true,
+        namSinh: { nam: 1952, thang: 10, ngay: 13 }, boId: 6, meId: 7,
+        honNhan: [{ voChongId: 2 }] }),
+      nguoiMau({ id: 2, hoTen: 'Hoa Ngọc Thanh', gioiTinh: 'nu', laThanhVienHo: false,
+        namSinh: { nam: 1959, thang: 12, ngay: 19 }, honNhan: [{ voChongId: 1 }] }),
+    ]
+
+    const data = makeData(persons)
+    const csv = exportGiaphaToCSV(data)
+    const result = importSingleCsvToGiapha(csv, METADATA)
+
+    expect(result.errors).toHaveLength(0)
+    expect(result.warnings).toHaveLength(0)
+    expect(result.stats.personCount).toBe(persons.length)
+
+    // Spot-check a person with commas in name
+    const cutTo = result.data!.persons[30]
+    expect(cutTo.hoTen).toBe('1. Hg Văn Bột, Cụ Tổ')
+    // Spot-check multi-spouse
+    const son = result.data!.persons[6]
+    expect(son.honNhan.map(h => h.voChongId).sort((a, b) => a - b)).toEqual([7, 16, 24])
+    // Spot-check tieuSu with comma
+    expect(son.tieuSu).toBe('Là Dũng sỹ diệt Mỹ, Dũng sỹ diệt máy bay.')
+  })
+})

--- a/src/utils/csvExport.ts
+++ b/src/utils/csvExport.ts
@@ -1,0 +1,89 @@
+import type { GiaphaData, NgayThang, Person } from '../types/giapha'
+
+// ─── Column order — must match csvImport.ts KNOWN_COLS ────────────────────────
+
+const HEADERS = [
+  'id', 'hoTen', 'gioiTinh', 'laThanhVienHo', 'thuTuAnhChi',
+  'namSinh_nam', 'namSinh_thang', 'namSinh_ngay', 'namSinh_amLich',
+  'namMat_nam', 'namMat_thang', 'namMat_ngay', 'namMat_amLich',
+  'boId', 'meId', 'voChongIds',
+  'queQuan', 'tieuSu', 'anhDaiDien', 'email', 'soDienThoai', 'ghiChu',
+] as const
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Wrap a field in quotes if it contains commas, quotes, or newlines. */
+function quoteField(value: string): string {
+  if (value.includes('"') || value.includes(',') || value.includes('\n') || value.includes('\r')) {
+    return '"' + value.replace(/"/g, '""') + '"'
+  }
+  return value
+}
+
+function flattenDate(d: NgayThang | undefined): [string, string, string, string] {
+  if (!d) return ['', '', '', '']
+  const nam = d.nam !== undefined ? String(d.nam) : ''
+  const thang = d.thang !== undefined ? String(d.thang) : ''
+  const ngay = d.ngay !== undefined ? String(d.ngay) : ''
+  const amLich = d.amLich !== undefined ? String(d.amLich) : ''
+  return [nam, thang, ngay, amLich]
+}
+
+function personToRow(p: Person): string[] {
+  const [sNam, sThang, sNgay, sAmLich] = flattenDate(p.namSinh)
+  const [mNam, mThang, mNgay, mAmLich] = flattenDate(p.namMat)
+  const voChongIds = p.honNhan.map(h => h.voChongId).join(';')
+
+  return [
+    String(p.id),
+    p.hoTen,
+    p.gioiTinh,
+    String(p.laThanhVienHo),
+    p.thuTuAnhChi !== undefined ? String(p.thuTuAnhChi) : '',
+    sNam, sThang, sNgay, sAmLich,
+    mNam, mThang, mNgay, mAmLich,
+    p.boId !== undefined ? String(p.boId) : '',
+    p.meId !== undefined ? String(p.meId) : '',
+    voChongIds,
+    p.queQuan ?? '',
+    p.tieuSu ?? '',
+    p.anhDaiDien ?? '',
+    p.email ?? '',
+    p.soDienThoai ?? '',
+    p.ghiChu ?? '',
+  ]
+}
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Serialise a GiaphaData object to a CSV string.
+ * The output is UTF-8 with a BOM prefix so Excel opens it correctly.
+ * Column order matches the import format exactly, enabling lossless round-trips.
+ */
+export function exportGiaphaToCSV(data: GiaphaData): string {
+  const headerLine = HEADERS.join(',')
+
+  const dataLines = Object.values(data.persons)
+    .sort((a, b) => a.id - b.id)
+    .map(person => personToRow(person).map(quoteField).join(','))
+
+  // BOM (\uFEFF) ensures Excel reads UTF-8 correctly on all platforms
+  return '\uFEFF' + [headerLine, ...dataLines].join('\r\n')
+}
+
+/**
+ * Trigger a file download in the browser.
+ */
+export function downloadCsv(filename: string, csvText: string): void {
+  const blob = new Blob([csvText], { type: 'text/csv;charset=utf-8;' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  a.style.display = 'none'
+  document.body.appendChild(a)
+  a.click()
+  document.body.removeChild(a)
+  URL.revokeObjectURL(url)
+}


### PR DESCRIPTION
## Tổng quan

Thêm tính năng xuất dữ liệu gia phả ra file CSV, đảm bảo round-trip lossless với import.

## Thay đổi

### `src/utils/csvExport.ts` (mới)
- `exportGiaphaToCSV(data)` — serialize GiaphaData → CSV string
  - **22 cột** đúng thứ tự như format import
  - **BOM** (`\uFEFF`) để Excel đọc UTF-8 đúng trên macOS/Windows
  - **Quoting** RFC 4180: fields chứa `,` hoặc `"` được wrap `"..."`
  - **Sort** persons theo `id` tăng dần (deterministic, dễ diff)
  - **`voChongIds`** export đủ cả 2 phía → reimport 0 warning `MISSING_REVERSE_SPOUSE_LINK`
  - Không export `conCaiIds` (reconstructed từ boId/meId khi import)
- `downloadCsv(filename, csvText)` — trigger browser download

### `src/utils/csvExport.test.ts` (mới) — 12 tests
**Unit tests:**
- Header đúng 22 cột
- BOM prefix
- NgayThang đầy đủ vs chỉ có năm
- Field chứa dấu phẩy → quoted
- Field chứa `"` → escaped
- voChongIds nhiều người → join `;`
- Sort by id ascending
- boId/meId xuất đúng

**Round-trip tests:**
- Simple family (3 người): `errors=0, warnings=0`
- Preserve tên (kể cả tên có dấy phẩy), ngày sinh đầy đủ, boId/meId
- Bidirectional marriage links preserved
- Large dataset (13 người đại diện): spot-check multi-spouse, tieuSu với dấy phẩy

### `src/components/Navbar.tsx` (sửa)
- Button **"Xuất CSV"** cạnh "Nhập CSV"
- Hiện khi: `data !== null && (role === 'admin' || role === 'editor')`
- Click → download ngay, không cần modal
- Filename: `giaphaHo{tenDongHo}_{YYYY-MM-DD}.csv`

## Test kết quả
- **86/86 tests pass** (73 cũ + 13 mới)
- **TypeScript 0 errors**

## Cách test thủ công
1. Login demo → import `docs/giaphahoHoang.csv` → click **Xuất CSV**
2. Mở file xuất trong Excel/Numbers → kiểm tra tên tiếng Việt OK
3. Import lại file vừa xuất → cây hiển thị y chang