### PR TITLE
Rich-text editor for article body with inline image upload

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,10 @@
       "name": "giapha",
       "version": "0.0.0",
       "dependencies": {
+        "@tiptap/extension-image": "^3.29.2",
+        "@tiptap/pm": "^3.29.2",
+        "@tiptap/react": "^3.29.2",
+        "@tiptap/starter-kit": "^3.29.2",
         "autoprefixer": "^10.5.0",
         "drizzle-orm": "^0.38.0",
         "hono": "^4.0.0",
@@ -18,6 +22,7 @@
         "react-router-dom": "^7.14.1",
         "relatives-tree": "^3.2.2",
         "tailwindcss": "^3.4.19",
+        "xss": "^1.0.15",
         "zustand": "^5.0.12"
       },
       "devDependencies": {
@@ -1774,6 +1779,34 @@
         }
       }
     },
+    "node_modules/@floating-ui/core": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.8.0.tgz",
+      "integrity": "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.12"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.8.0.tgz",
+      "integrity": "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@floating-ui/core": "^1.8.0",
+        "@floating-ui/utils": "^0.2.12"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz",
+      "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -2959,6 +2992,449 @@
         "@testing-library/dom": ">=7.21.4"
       }
     },
+    "node_modules/@tiptap/core": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.29.2.tgz",
+      "integrity": "sha512-oKUkiPUB7noilVYxI9lNzUD4rX17sHub+PYjMfHMWHG9A3nvIy+FdePIVIIhThKWF7ijhr3eIqHY51Bn+GAFtw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/pm": "3.29.2"
+      }
+    },
+    "node_modules/@tiptap/extension-blockquote": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-blockquote/-/extension-blockquote-3.29.2.tgz",
+      "integrity": "sha512-ca4OzKDh0yaxg2+Z56bC2QnWsNsFp2YMRfVig1PDXyMVFMNJpLcnhxgq/9btn+xYAlYrj8RymOeCTYREOR6Zjg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.29.2",
+        "@tiptap/pm": "3.29.2"
+      }
+    },
+    "node_modules/@tiptap/extension-bold": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bold/-/extension-bold-3.29.2.tgz",
+      "integrity": "sha512-elYbGxJsYnBb4leqrcjdIJuiG380BcOgN+UUzvOv+qEjfGVzHodFOMBl3qnmD6urYHNu5/qQK2S0qSSRXKCLNQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.29.2"
+      }
+    },
+    "node_modules/@tiptap/extension-bubble-menu": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bubble-menu/-/extension-bubble-menu-3.29.2.tgz",
+      "integrity": "sha512-kzcWarcpr031rZu+R3Hzut5uxb3Qj/xxMDEYZIQ3uiq1yb5vEMXj8/SIyWautk6Nu8Rr1leV3rGdR4NzhzyFAA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@floating-ui/dom": "^1.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.29.2",
+        "@tiptap/pm": "3.29.2"
+      }
+    },
+    "node_modules/@tiptap/extension-bullet-list": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bullet-list/-/extension-bullet-list-3.29.2.tgz",
+      "integrity": "sha512-3bWcCUPbCHv0XttlMdnAtXLNYWx2pblByMgxmGsaP9FU0QnslGXty6A6gHCqI33ygRg1vrA6U5Wtpwbi5aKu5g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "3.29.2"
+      }
+    },
+    "node_modules/@tiptap/extension-code": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code/-/extension-code-3.29.2.tgz",
+      "integrity": "sha512-c6W5UGuB7WNLpYocsgRzpO2OOTI4QjaI9jjHRMuty9z+s9DtaYM/HrRLNwVh6MopkHb+i/89Wkv8gCS34fftig==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.29.2"
+      }
+    },
+    "node_modules/@tiptap/extension-code-block": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-3.29.2.tgz",
+      "integrity": "sha512-w153ct8g6dLiPTdXQ6SOIMxX4SEo5Q50AmjdEEEcJ7ZcYUcde/ScSskLHfOYmyt5ZFAiyEwr121+pux+p3/oAQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.29.2",
+        "@tiptap/pm": "3.29.2"
+      }
+    },
+    "node_modules/@tiptap/extension-document": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-document/-/extension-document-3.29.2.tgz",
+      "integrity": "sha512-YUamvefLnsqu6124GavVTI7nqcFlQJ12ROB0oSwG69eSBZYNjg1tIs05LFrBxkwf4Xgqd6YzfJ9+FeG428RvzQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.29.2"
+      }
+    },
+    "node_modules/@tiptap/extension-dropcursor": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-dropcursor/-/extension-dropcursor-3.29.2.tgz",
+      "integrity": "sha512-KKno7cU9r1HdR48CRrsDu69/1UjZdoslq/UcE+Kx+tdhAv/aljXMkRSNzGMrBNOBDmHRgS1+58zm21WQWdQzwA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extensions": "3.29.2"
+      }
+    },
+    "node_modules/@tiptap/extension-floating-menu": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-floating-menu/-/extension-floating-menu-3.29.2.tgz",
+      "integrity": "sha512-CBTq4Xs5aGWr65uFCIkKBms796OhmirWf/ax//iJ4fl9IfwqjwFuc2vQs9PmuwpKn9ctDHo2sMTtvyeCvIt5LQ==",
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@floating-ui/dom": "^1.0.0",
+        "@tiptap/core": "3.29.2",
+        "@tiptap/pm": "3.29.2"
+      }
+    },
+    "node_modules/@tiptap/extension-gapcursor": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-gapcursor/-/extension-gapcursor-3.29.2.tgz",
+      "integrity": "sha512-8Q39UR4/Tit759IeW9xZIe3NMwN11GsuA3FLheDyyGn7RrW02HD3HhUDlazE54Ki4HoosjFmChPlN4Ik2ubdRQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extensions": "3.29.2"
+      }
+    },
+    "node_modules/@tiptap/extension-hard-break": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-hard-break/-/extension-hard-break-3.29.2.tgz",
+      "integrity": "sha512-eUW3LN3fq8rXnjEUeI3D2QONYdLsU3yYQm4jxlErs2h4cfwrFjgf19VSUFVmm6LrFbbQ0OnDVPeVLL6iOwDw2w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.29.2"
+      }
+    },
+    "node_modules/@tiptap/extension-heading": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-heading/-/extension-heading-3.29.2.tgz",
+      "integrity": "sha512-6W4aIy70Mh7BNlbG9zZ5FBLhJhU2UUEzgZJ/jwYSCcB30o8McLxJSEjhtoHiX8R78Ah2/JzBGvIe5olZlbeE4A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.29.2"
+      }
+    },
+    "node_modules/@tiptap/extension-horizontal-rule": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-horizontal-rule/-/extension-horizontal-rule-3.29.2.tgz",
+      "integrity": "sha512-8/ZPzbB9X85Mc9/7xVLZupQKBr2UVcQTGr512xtqMW+XkCQRHCph46tRo828YE13IMWI5fWn/FaNCqXG9cULSw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.29.2",
+        "@tiptap/pm": "3.29.2"
+      }
+    },
+    "node_modules/@tiptap/extension-image": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-image/-/extension-image-3.29.2.tgz",
+      "integrity": "sha512-F+S4iru247mNVZdkNwNDZHeb281DkjsBJinaOGsOyJTvXY+KU5Uq7vY1LQTn493dTfU48Z0yMBUXwJffCT92Mg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.29.2"
+      }
+    },
+    "node_modules/@tiptap/extension-italic": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-italic/-/extension-italic-3.29.2.tgz",
+      "integrity": "sha512-iH63V/5wsaMnY4Jz0+meaAGhaec4AiOzOduzl6ZZr5IyGhZ1kthyW84ELt0dyLI3hNceAUhaNWc+I7+vX0aoXA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.29.2"
+      }
+    },
+    "node_modules/@tiptap/extension-link": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-link/-/extension-link-3.29.2.tgz",
+      "integrity": "sha512-DcVer5SqrexKCEP6Ip1UPxJUMvcRCCItSv0wxoGytanrimBh2smvcg6X0DWnjlsi5H0updhyl+atYCmmQXUIXA==",
+      "license": "MIT",
+      "dependencies": {
+        "linkifyjs": "^4.3.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.29.2",
+        "@tiptap/pm": "3.29.2"
+      }
+    },
+    "node_modules/@tiptap/extension-list": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.29.2.tgz",
+      "integrity": "sha512-WPZ9BHAPT6QeIm1vdVkuoOWvy9a8/EZeJwV2VhU8LXyTAttvzyj4rsbbHyJWvYWlUSTt/QF2AZ2zhKo7u1w3/A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.29.2",
+        "@tiptap/pm": "3.29.2"
+      }
+    },
+    "node_modules/@tiptap/extension-list-item": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-item/-/extension-list-item-3.29.2.tgz",
+      "integrity": "sha512-s8vBVHHFT0Qpu7CzAZ7S1kYmSiVaDvUNvMNcZUWnxj6VPfiwmx0eXd9FsjePrRCMoM5tFmPnhFTHDxY3D/eZeQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "3.29.2"
+      }
+    },
+    "node_modules/@tiptap/extension-list-keymap": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-keymap/-/extension-list-keymap-3.29.2.tgz",
+      "integrity": "sha512-R+3k8OLnxdCH7Xy9ieOwUt5m2Je74u8mikothGmsYVO2Zyq48fIbmZ+X6RBPCu7DBOI2FIUhHEFbKQeDWvDNmA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "3.29.2"
+      }
+    },
+    "node_modules/@tiptap/extension-ordered-list": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-ordered-list/-/extension-ordered-list-3.29.2.tgz",
+      "integrity": "sha512-ndCunC+UsYOpkOtL7vGnDz21UNa45WUlcO9wMT1fbuYow2QnRhsuMlCWENXI52YPPARWuQ0RDgN7q6TaxPERBg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "3.29.2"
+      }
+    },
+    "node_modules/@tiptap/extension-paragraph": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-paragraph/-/extension-paragraph-3.29.2.tgz",
+      "integrity": "sha512-7qJj5YTr11vvjNgjDN1ypOfwTovc0QOCYcit/rskeuVgnmQZOZQzC/BbyKLLG7UGnpRLemU/mEGbW9pAqjAXkQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.29.2"
+      }
+    },
+    "node_modules/@tiptap/extension-strike": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-strike/-/extension-strike-3.29.2.tgz",
+      "integrity": "sha512-aEvLAbddUQZ+FukCreV3q4G2HfNI+odE7E9U+wbq6XsSWKyo8/pDu1muz+TFKNre4blSMOQ3JQmw5UeHDKy+fg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.29.2"
+      }
+    },
+    "node_modules/@tiptap/extension-text": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-text/-/extension-text-3.29.2.tgz",
+      "integrity": "sha512-Ubko45JWWHe8glBt2PiGNF8hcbys/JNalFhiR7Y1X4iOOtAxAKJJxh3+eq+//NTlGuBPdWGp7zw8EEUp7anjKA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.29.2"
+      }
+    },
+    "node_modules/@tiptap/extension-underline": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-underline/-/extension-underline-3.29.2.tgz",
+      "integrity": "sha512-K7XwH/xS/5AIREWQ00VTEf/W5U0olp7j6wwit7cdd/8nHv6h6AGr1+iEApHKoLXWQZLfGQKzJlT9W61LAl+fHA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.29.2"
+      }
+    },
+    "node_modules/@tiptap/extensions": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.29.2.tgz",
+      "integrity": "sha512-BCz+FCAChSYtUe4BFj97HEO+nSK+J7GxbJgZG4Hg7DT/gI+hRyeNndU8efiQAx3WGdzsFi3UxRpcF1tTQM7iMQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.29.2",
+        "@tiptap/pm": "3.29.2"
+      }
+    },
+    "node_modules/@tiptap/pm": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.29.2.tgz",
+      "integrity": "sha512-GCOme7xHaS+DSoaA4CDcAD3l6JyBlvZhvCyfsy2Vp6j8tEoBkZWio7soYVosmlyn7zq8/64VeFZP5s47yfG7fQ==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-changeset": "^2.4.1",
+        "prosemirror-commands": "^1.7.1",
+        "prosemirror-dropcursor": "^1.8.2",
+        "prosemirror-gapcursor": "^1.4.1",
+        "prosemirror-history": "^1.5.0",
+        "prosemirror-inputrules": "^1.5.1",
+        "prosemirror-keymap": "^1.2.3",
+        "prosemirror-model": "^1.25.11",
+        "prosemirror-schema-list": "^1.5.1",
+        "prosemirror-state": "^1.4.4",
+        "prosemirror-tables": "^1.8.5",
+        "prosemirror-transform": "^1.12.0",
+        "prosemirror-view": "^1.41.9"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      }
+    },
+    "node_modules/@tiptap/react": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/react/-/react-3.29.2.tgz",
+      "integrity": "sha512-ZMKgteYmZXnq7C22U9fbCTC6jAF8XlQM5n2K2FLWCdYAlP4FNV3XeQ9hY2a13KSQ0Q3yltWXZlcWBpt5ClxScg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "fast-equals": "^5.3.3",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "optionalDependencies": {
+        "@tiptap/extension-bubble-menu": "^3.29.2",
+        "@tiptap/extension-floating-menu": "^3.29.2"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.29.2",
+        "@tiptap/pm": "3.29.2",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tiptap/starter-kit": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/starter-kit/-/starter-kit-3.29.2.tgz",
+      "integrity": "sha512-oTu0tysiqk4zgjEtxRHjAQgxUKaAevZwueOWwSWubHdokqp7SpcbE5n9USJv89HKuTUDm3GjnQH6q8HNn/2DsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tiptap/core": "^3.29.2",
+        "@tiptap/extension-blockquote": "^3.29.2",
+        "@tiptap/extension-bold": "^3.29.2",
+        "@tiptap/extension-bullet-list": "^3.29.2",
+        "@tiptap/extension-code": "^3.29.2",
+        "@tiptap/extension-code-block": "^3.29.2",
+        "@tiptap/extension-document": "^3.29.2",
+        "@tiptap/extension-dropcursor": "^3.29.2",
+        "@tiptap/extension-gapcursor": "^3.29.2",
+        "@tiptap/extension-hard-break": "^3.29.2",
+        "@tiptap/extension-heading": "^3.29.2",
+        "@tiptap/extension-horizontal-rule": "^3.29.2",
+        "@tiptap/extension-italic": "^3.29.2",
+        "@tiptap/extension-link": "^3.29.2",
+        "@tiptap/extension-list": "^3.29.2",
+        "@tiptap/extension-list-item": "^3.29.2",
+        "@tiptap/extension-list-keymap": "^3.29.2",
+        "@tiptap/extension-ordered-list": "^3.29.2",
+        "@tiptap/extension-paragraph": "^3.29.2",
+        "@tiptap/extension-strike": "^3.29.2",
+        "@tiptap/extension-text": "^3.29.2",
+        "@tiptap/extension-underline": "^3.29.2",
+        "@tiptap/extensions": "^3.29.2",
+        "@tiptap/pm": "^3.29.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -3034,7 +3510,6 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -3044,11 +3519,16 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.58.2",
@@ -3997,11 +4477,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/cssfilter": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
+      "integrity": "sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw==",
+      "license": "MIT"
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/data-urls": {
@@ -5008,6 +5493,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-equals": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.4.1.tgz",
+      "integrity": "sha512-DjlFSM5Pk9cGcL0q5QXl66eGzx0N6szNgaswwc5ZphlBohjTVJSnGgI+rJVOgOi65qUoQnDZN4nDqi33udtydQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/fast-glob": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
@@ -5909,6 +6403,12 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "license": "MIT"
     },
+    "node_modules/linkifyjs": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.3.tgz",
+      "integrity": "sha512-P8aEP5U/D1/IlTY2OeYsErdwh9bGuLE30NcXtKEjgdHcahveQoQwM2yZNsioQHsWFz0P7KKudisbrzCgR0sDHg==",
+      "license": "MIT"
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -6159,6 +6659,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/orderedmap": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-2.1.1.tgz",
+      "integrity": "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==",
+      "license": "MIT"
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
@@ -6496,6 +7002,145 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/prosemirror-changeset": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-changeset/-/prosemirror-changeset-2.4.1.tgz",
+      "integrity": "sha512-96WBLhOaYhJ+kPhLg3uW359Tz6I/MfcrQfL4EGv4SrcqKEMC1gmoGrXHecPE8eOwTVCJ4IwgfzM8fFad25wNfw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-commands": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.7.2.tgz",
+      "integrity": "sha512-q6Q6szxqdu9Xd6EcdKsqXghu5nQdZTpB4Q9yd04WRc7/jt763e/rT60Owh0L1GYY+T46o5rD+9lEN36dZS43tw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.10.2"
+      }
+    },
+    "node_modules/prosemirror-dropcursor": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/prosemirror-dropcursor/-/prosemirror-dropcursor-1.8.3.tgz",
+      "integrity": "sha512-FoYbsJR8gK+DGlqhNoE29Loa38eIZPzQRIb1VMaDNBoo4OLP6vVof/jR8qFY/6XvUd6Dhug8MDCHl2a/h8RTfQ==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0",
+        "prosemirror-view": "^1.1.0"
+      }
+    },
+    "node_modules/prosemirror-gapcursor": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.4.1.tgz",
+      "integrity": "sha512-pMdYaEnjNMSwl11yjEGtgTmLkR08m/Vl+Jj443167p9eB3HVQKhYCc4gmHVDsLPODfZfjr/MmirsdyZziXbQKw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-keymap": "^1.0.0",
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-view": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-history": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-history/-/prosemirror-history-1.5.0.tgz",
+      "integrity": "sha512-zlzTiH01eKA55UAf1MEjtssJeHnGxO0j4K4Dpx+gnmX9n+SHNlDqI2oO1Kv1iPN5B1dm5fsljCfqKF9nFL6HRg==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.2.2",
+        "prosemirror-transform": "^1.0.0",
+        "prosemirror-view": "^1.31.0",
+        "rope-sequence": "^1.3.0"
+      }
+    },
+    "node_modules/prosemirror-inputrules": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-inputrules/-/prosemirror-inputrules-1.5.1.tgz",
+      "integrity": "sha512-7wj4uMjKaXWAQ1CDgxNzNtR9AlsuwzHfdFH1ygEHA2KHF2DOEaXl1CJfNPAKCg9qNEh4rum975QLaCiQPyY6Fw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-keymap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/prosemirror-keymap/-/prosemirror-keymap-1.2.3.tgz",
+      "integrity": "sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "w3c-keyname": "^2.2.0"
+      }
+    },
+    "node_modules/prosemirror-model": {
+      "version": "1.25.11",
+      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.11.tgz",
+      "integrity": "sha512-QWg9RhnpLlogAmp3p96uEFrE5txQpFynd4vhBAELkwgOCWQs/X0yCzB3/hrHqiPwf91RG5KyWq6553zs9JqIOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "orderedmap": "^2.0.0"
+      }
+    },
+    "node_modules/prosemirror-schema-list": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-schema-list/-/prosemirror-schema-list-1.5.1.tgz",
+      "integrity": "sha512-927lFx/uwyQaGwJxLWCZRkjXG0p48KpMj6ueoYiu4JX05GGuGcgzAy62dfiV8eFZftgyBUvLx76RsMe20fJl+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.7.3"
+      }
+    },
+    "node_modules/prosemirror-state": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
+      "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-transform": "^1.0.0",
+        "prosemirror-view": "^1.27.0"
+      }
+    },
+    "node_modules/prosemirror-tables": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-1.8.5.tgz",
+      "integrity": "sha512-V/0cDCsHKHe/tfWkeCmthNUcEp1IVO3p6vwN8XtwE9PZQLAZJigbw3QoraAdfJPir4NKJtNvOB8oYGKRl+t0Dw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-keymap": "^1.2.3",
+        "prosemirror-model": "^1.25.4",
+        "prosemirror-state": "^1.4.4",
+        "prosemirror-transform": "^1.10.5",
+        "prosemirror-view": "^1.41.4"
+      }
+    },
+    "node_modules/prosemirror-transform": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.12.0.tgz",
+      "integrity": "sha512-GxboyN4AMIsoHNtz5uf2r2Ru551i5hWeCMD6E2Ib4Eogqoub0NflniaBPVQ4MrGE5yZ8JV9tUHg9qcZTTrcN4w==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.21.0"
+      }
+    },
+    "node_modules/prosemirror-view": {
+      "version": "1.42.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.42.2.tgz",
+      "integrity": "sha512-Pdg0l5kXm8aLDquFAnQFTCITg0q44sLqBlHlpsVLD9segdOao8TOfQdAhCrCXyVgPSRr6UDDROOIWA3bIrN9YQ==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.25.8",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -6746,6 +7391,12 @@
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.15.tgz",
       "integrity": "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rope-sequence": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/rope-sequence/-/rope-sequence-1.3.4.tgz",
+      "integrity": "sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==",
       "license": "MIT"
     },
     "node_modules/run-parallel": {
@@ -7360,6 +8011,15 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -7533,6 +8193,12 @@
           "optional": false
         }
       }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
     },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",
@@ -7719,6 +8385,28 @@
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/xss": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.15.tgz",
+      "integrity": "sha512-FVdlVVC67WOIPvfOwhoMETV72f6GbW7aOabBC3WxN/oUdoEMDyLz4OgRv5/gck2ZeNqEQu+Tb0kloovXOfpYVg==",
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^2.20.3",
+        "cssfilter": "0.0.10"
+      },
+      "bin": {
+        "xss": "bin/xss"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/xss/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "license": "MIT"
     },
     "node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,10 @@
     "test:worker": "vitest run --config worker/vitest.config.ts"
   },
   "dependencies": {
+    "@tiptap/extension-image": "^3.29.2",
+    "@tiptap/pm": "^3.29.2",
+    "@tiptap/react": "^3.29.2",
+    "@tiptap/starter-kit": "^3.29.2",
     "autoprefixer": "^10.5.0",
     "drizzle-orm": "^0.38.0",
     "hono": "^4.0.0",
@@ -25,6 +29,7 @@
     "react-router-dom": "^7.14.1",
     "relatives-tree": "^3.2.2",
     "tailwindcss": "^3.4.19",
+    "xss": "^1.0.15",
     "zustand": "^5.0.12"
   },
   "devDependencies": {

--- a/src/components/ArticleManagementView.test.tsx
+++ b/src/components/ArticleManagementView.test.tsx
@@ -5,6 +5,17 @@ import * as api from '../services/api'
 
 vi.mock('../services/api')
 
+// RichTextEditor wraps Tiptap/ProseMirror, which relies on real-browser
+// contenteditable/selection APIs not available in jsdom. Stub it with a plain
+// textarea driven by the same value/onChange/id/ariaLabel contract so these
+// tests can keep exercising ArticleManagementView's own form wiring; the
+// editor's own behavior is covered by RichTextEditor.test.tsx.
+vi.mock('./RichTextEditor', () => ({
+  default: ({ id, value, onChange }: { id?: string; value: string; onChange: (v: string) => void }) => (
+    <textarea id={id} value={value} onChange={e => onChange(e.target.value)} />
+  ),
+}))
+
 const sampleCategories = [
   {
     id: 'cat-1',

--- a/src/components/ArticleManagementView.tsx
+++ b/src/components/ArticleManagementView.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import * as api from '../services/api'
 import type { Article, ArticleCategory } from '../types/giapha'
+import RichTextEditor from './RichTextEditor'
 
 type ArticleStatus = 'draft' | 'published'
 
@@ -316,14 +317,7 @@ export default function ArticleManagementView() {
           </div>
           <div>
             <label htmlFor="new-article-body" className="block text-sm text-gray-600 mb-1">Nội dung</label>
-            <textarea
-              id="new-article-body"
-              value={body}
-              onChange={e => setBody(e.target.value)}
-              required
-              rows={6}
-              className="w-full px-3 py-2 text-sm border border-gray-300 rounded-md"
-            />
+            <RichTextEditor id="new-article-body" value={body} onChange={setBody} ariaLabel="Nội dung bài viết mới" />
           </div>
           <div>
             <label htmlFor="new-article-status" className="block text-sm text-gray-600 mb-1">Trạng thái</label>
@@ -409,13 +403,11 @@ export default function ArticleManagementView() {
                 </div>
                 <div>
                   <label htmlFor={`edit-body-${article.id}`} className="block text-sm text-gray-600 mb-1">Nội dung</label>
-                  <textarea
+                  <RichTextEditor
                     id={`edit-body-${article.id}`}
                     value={editBody}
-                    onChange={e => setEditBody(e.target.value)}
-                    required
-                    rows={6}
-                    className="w-full px-3 py-2 text-sm border border-gray-300 rounded-md"
+                    onChange={setEditBody}
+                    ariaLabel={`Nội dung bài viết ${article.title}`}
                   />
                 </div>
                 <div>

--- a/src/components/RichTextEditor.css
+++ b/src/components/RichTextEditor.css
@@ -1,0 +1,95 @@
+.rte-wrapper {
+  border: 1px solid #d1d5db;
+  border-radius: 0.375rem;
+  overflow: hidden;
+}
+
+.rte-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.375rem 0.5rem;
+  background: #f9fafb;
+  border-bottom: 1px solid #d1d5db;
+}
+
+.rte-toolbar-btn {
+  min-width: 1.75rem;
+  height: 1.75rem;
+  padding: 0 0.375rem;
+  font-size: 0.8125rem;
+  line-height: 1;
+  border-radius: 0.25rem;
+  border: 1px solid transparent;
+  background: transparent;
+  color: #374151;
+  cursor: pointer;
+}
+
+.rte-toolbar-btn:hover {
+  background: #e5e7eb;
+}
+
+.rte-toolbar-btn-active {
+  background: #dbeafe;
+  border-color: #93c5fd;
+  color: #1d4ed8;
+}
+
+.rte-toolbar-divider {
+  width: 1px;
+  height: 1.25rem;
+  background: #d1d5db;
+  margin: 0 0.25rem;
+}
+
+.rte-content {
+  min-height: 10rem;
+  max-height: 28rem;
+  overflow-y: auto;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.875rem;
+  color: #111827;
+  outline: none;
+}
+
+.rte-content p {
+  margin: 0 0 0.75rem;
+}
+
+.rte-content h2 {
+  font-size: 1.125rem;
+  font-weight: 600;
+  margin: 1rem 0 0.5rem;
+}
+
+.rte-content h3 {
+  font-size: 1rem;
+  font-weight: 600;
+  margin: 0.875rem 0 0.5rem;
+}
+
+.rte-content ul,
+.rte-content ol {
+  margin: 0 0 0.75rem 1.25rem;
+}
+
+.rte-content blockquote {
+  margin: 0 0 0.75rem;
+  padding-left: 0.75rem;
+  border-left: 3px solid #d1d5db;
+  color: #4b5563;
+  font-style: italic;
+}
+
+.rte-content a {
+  color: #2563eb;
+  text-decoration: underline;
+}
+
+.rte-content img {
+  max-width: 100%;
+  border-radius: 0.25rem;
+  margin: 0.5rem 0;
+}

--- a/src/components/RichTextEditor.test.tsx
+++ b/src/components/RichTextEditor.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import RichTextEditor from './RichTextEditor'
+import * as api from '../services/api'
+
+vi.mock('../services/api')
+
+describe('RichTextEditor', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders the initial HTML content', async () => {
+    render(<RichTextEditor value="<p>Xin chào</p>" onChange={vi.fn()} ariaLabel="Nội dung" />)
+
+    await waitFor(() => expect(screen.getByText('Xin chào')).toBeInTheDocument())
+  })
+
+  it('renders a formatting toolbar with the expected buttons', async () => {
+    render(<RichTextEditor value="<p>Nội dung</p>" onChange={vi.fn()} ariaLabel="Nội dung" />)
+
+    await waitFor(() => expect(screen.getByRole('toolbar')).toBeInTheDocument())
+    expect(screen.getByRole('button', { name: 'Đậm' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Nghiêng' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Chèn ảnh' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Chèn liên kết' })).toBeInTheDocument()
+  })
+
+  it('uploads a picked image and inserts it into the document', async () => {
+    vi.mocked(api.uploadArticleImage).mockResolvedValue({ url: '/api/avatars/article-content/abc.jpg' })
+
+    render(<RichTextEditor value="<p></p>" onChange={vi.fn()} ariaLabel="Nội dung" />)
+    await waitFor(() => expect(screen.getByRole('toolbar')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByRole('button', { name: 'Chèn ảnh' }))
+
+    const file = new File(['fake-image-bytes'], 'photo.jpg', { type: 'image/jpeg' })
+    const fileInput = screen.getByLabelText('Chọn ảnh để chèn vào nội dung') as HTMLInputElement
+    fireEvent.change(fileInput, { target: { files: [file] } })
+
+    await waitFor(() => expect(api.uploadArticleImage).toHaveBeenCalledWith(file))
+    await waitFor(() => expect(document.querySelector('img[src="/api/avatars/article-content/abc.jpg"]')).toBeInTheDocument())
+  })
+})

--- a/src/components/RichTextEditor.tsx
+++ b/src/components/RichTextEditor.tsx
@@ -1,0 +1,151 @@
+import { useEditor, EditorContent, type Editor } from '@tiptap/react'
+import StarterKit from '@tiptap/starter-kit'
+import Image from '@tiptap/extension-image'
+import { useRef } from 'react'
+import * as api from '../services/api'
+import './RichTextEditor.css'
+
+type RichTextEditorProps = {
+  value: string
+  onChange: (html: string) => void
+  id?: string
+  ariaLabel?: string
+}
+
+function ToolbarButton({
+  onClick,
+  active,
+  label,
+  children,
+}: {
+  onClick: () => void
+  active?: boolean
+  label: string
+  children: React.ReactNode
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={label}
+      aria-pressed={active}
+      className={`rte-toolbar-btn${active ? ' rte-toolbar-btn-active' : ''}`}
+    >
+      {children}
+    </button>
+  )
+}
+
+function Toolbar({ editor, onPickImage }: { editor: Editor; onPickImage: () => void }) {
+  return (
+    <div className="rte-toolbar" role="toolbar" aria-label="Định dạng văn bản">
+      <ToolbarButton label="Đậm" active={editor.isActive('bold')} onClick={() => editor.chain().focus().toggleBold().run()}>
+        <strong>B</strong>
+      </ToolbarButton>
+      <ToolbarButton label="Nghiêng" active={editor.isActive('italic')} onClick={() => editor.chain().focus().toggleItalic().run()}>
+        <em>I</em>
+      </ToolbarButton>
+      <ToolbarButton label="Gạch chân" active={editor.isActive('underline')} onClick={() => editor.chain().focus().toggleUnderline().run()}>
+        <u>U</u>
+      </ToolbarButton>
+      <ToolbarButton label="Gạch ngang" active={editor.isActive('strike')} onClick={() => editor.chain().focus().toggleStrike().run()}>
+        <s>S</s>
+      </ToolbarButton>
+      <span className="rte-toolbar-divider" />
+      <ToolbarButton label="Tiêu đề 2" active={editor.isActive('heading', { level: 2 })} onClick={() => editor.chain().focus().toggleHeading({ level: 2 }).run()}>
+        H2
+      </ToolbarButton>
+      <ToolbarButton label="Tiêu đề 3" active={editor.isActive('heading', { level: 3 })} onClick={() => editor.chain().focus().toggleHeading({ level: 3 }).run()}>
+        H3
+      </ToolbarButton>
+      <span className="rte-toolbar-divider" />
+      <ToolbarButton label="Danh sách gạch đầu dòng" active={editor.isActive('bulletList')} onClick={() => editor.chain().focus().toggleBulletList().run()}>
+        •≡
+      </ToolbarButton>
+      <ToolbarButton label="Danh sách đánh số" active={editor.isActive('orderedList')} onClick={() => editor.chain().focus().toggleOrderedList().run()}>
+        1≡
+      </ToolbarButton>
+      <ToolbarButton label="Trích dẫn" active={editor.isActive('blockquote')} onClick={() => editor.chain().focus().toggleBlockquote().run()}>
+        "
+      </ToolbarButton>
+      <span className="rte-toolbar-divider" />
+      <ToolbarButton
+        label="Chèn liên kết"
+        active={editor.isActive('link')}
+        onClick={() => {
+          const previousUrl = editor.getAttributes('link').href as string | undefined
+          const url = window.prompt('Nhập địa chỉ liên kết:', previousUrl ?? 'https://')
+          if (url === null) return
+          if (url.trim() === '') {
+            editor.chain().focus().extendMarkRange('link').unsetLink().run()
+            return
+          }
+          editor.chain().focus().extendMarkRange('link').setLink({ href: url.trim() }).run()
+        }}
+      >
+        🔗
+      </ToolbarButton>
+      <ToolbarButton label="Chèn ảnh" onClick={onPickImage}>
+        🖼
+      </ToolbarButton>
+    </div>
+  )
+}
+
+/**
+ * Rich-text editor for article body content, built on Tiptap. Emits sanitized
+ * HTML via `onChange`; the server independently re-sanitizes on save, so this
+ * component doesn't need its own sanitization step.
+ */
+export default function RichTextEditor({ value, onChange, id, ariaLabel }: RichTextEditorProps) {
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  const editor = useEditor({
+    extensions: [
+      StarterKit.configure({
+        link: { openOnClick: false, HTMLAttributes: { target: '_blank', rel: 'noopener noreferrer' } },
+      }),
+      Image,
+    ],
+    content: value,
+    onUpdate: ({ editor: updatedEditor }) => {
+      onChange(updatedEditor.getHTML())
+    },
+    editorProps: {
+      attributes: {
+        id: id ?? '',
+        'aria-label': ariaLabel ?? 'Nội dung bài viết',
+        class: 'rte-content',
+      },
+    },
+  })
+
+  async function handleFileSelected(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0]
+    e.target.value = ''
+    if (!file || !editor) return
+    try {
+      const { url } = await api.uploadArticleImage(file)
+      editor.chain().focus().setImage({ src: url }).run()
+    } catch {
+      window.alert('Tải ảnh lên thất bại. Vui lòng thử lại.')
+    }
+  }
+
+  if (!editor) return null
+
+  return (
+    <div className="rte-wrapper">
+      <Toolbar editor={editor} onPickImage={() => fileInputRef.current?.click()} />
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/*"
+        className="sr-only"
+        aria-label="Chọn ảnh để chèn vào nội dung"
+        onChange={handleFileSelected}
+      />
+      <EditorContent editor={editor} />
+    </div>
+  )
+}

--- a/src/pages/LandingPage.css
+++ b/src/pages/LandingPage.css
@@ -510,6 +510,45 @@
   font-size: 0.92rem;
   line-height: 1.9;
 }
+.landing-page .lp-article-body h2 {
+  margin: 32px 0 16px;
+  color: var(--ink);
+  font: 700 1.35rem/1.4 'IBM Plex Serif', serif;
+}
+.landing-page .lp-article-body h3 {
+  margin: 28px 0 14px;
+  color: var(--ink);
+  font: 700 1.15rem/1.4 'IBM Plex Serif', serif;
+}
+.landing-page .lp-article-body ul,
+.landing-page .lp-article-body ol {
+  margin: 0 0 20px;
+  padding-left: 1.4em;
+  color: var(--ink);
+  font-size: 0.92rem;
+  line-height: 1.9;
+}
+.landing-page .lp-article-body blockquote {
+  margin: 0 0 20px;
+  padding: 4px 0 4px 20px;
+  border-left: 3px solid var(--brick);
+  color: var(--ink-soft, var(--ink));
+  font-style: italic;
+}
+.landing-page .lp-article-body a {
+  color: var(--brick);
+  text-decoration: underline;
+}
+.landing-page .lp-article-body img {
+  display: block;
+  max-width: 100%;
+  height: auto;
+  margin: 24px 0;
+  border-radius: 5px;
+}
+.landing-page .lp-article-body strong {
+  font-weight: 700;
+}
 
 @media (max-width: 960px) {
   .landing-page {

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -37,7 +37,8 @@ function formatArticleDate(publishedAt: string | null): string {
 }
 
 function estimateReadingMinutes(body: string): string {
-  const wordCount = body.trim().split(/\s+/).filter(Boolean).length
+  const plainText = body.replace(/<[^>]*>/g, ' ')
+  const wordCount = plainText.trim().split(/\s+/).filter(Boolean).length
   const minutes = Math.max(1, Math.round(wordCount / 200))
   return `${minutes} phút đọc`
 }
@@ -75,13 +76,6 @@ function pickNearestUpcomingEvent(events: EventItem[]): EventItem | null {
 
 function getCategoryAnchorId(category: ArticleCategory) {
   return `category-${category.slug || category.id}`
-}
-
-function splitBodyIntoParagraphs(body: string): string[] {
-  return body
-    .split(/\n{2,}/)
-    .map(paragraph => paragraph.trim())
-    .filter(Boolean)
 }
 
 export default function LandingPage() {
@@ -296,11 +290,12 @@ export default function LandingPage() {
                       </div>
                     )}
                     <p className="lp-article-summary">{activeArticle.summary}</p>
-                    <div className="lp-article-body">
-                      {splitBodyIntoParagraphs(activeArticle.body).map((paragraph, index) => (
-                        <p key={index}>{paragraph}</p>
-                      ))}
-                    </div>
+                    <div
+                      className="lp-article-body"
+                      // Body HTML is sanitized server-side (xss allowlist) on every
+                      // create/update, so it's safe to render directly here.
+                      dangerouslySetInnerHTML={{ __html: activeArticle.body }}
+                    />
                   </article>
                 </>
               ) : (

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -208,6 +208,13 @@ export function uploadArticleCover(id: string, file: File): Promise<Article> {
   return request<Article>(`/api/articles/${id}/cover`, { method: 'POST', body: formData })
 }
 
+/** Uploads an image for inline use in a rich-text article body (not tied to any article id). */
+export function uploadArticleImage(file: File): Promise<{ url: string }> {
+  const formData = new FormData()
+  formData.append('file', file)
+  return request<{ url: string }>('/api/article-images', { method: 'POST', body: formData })
+}
+
 export function listEvents(): Promise<EventItem[]> {
   return request<EventItem[]>('/api/events')
 }

--- a/worker/src/lib/sanitize-html.ts
+++ b/worker/src/lib/sanitize-html.ts
@@ -1,0 +1,43 @@
+// The `xss` package's CJS module assigns `module.exports = filterXSS` (a
+// callable function with `.filterXSS`/`.FilterXSS` properties attached to
+// it), rather than a plain object of named exports. Under the bundler used
+// by vitest-pool-workers/wrangler, named imports (`import { filterXSS }`)
+// fail to resolve because the CJS-to-ESM interop only recognizes a `default`
+// export for a function-shaped `module.exports`. Importing the default and
+// calling it directly (it *is* the `filterXSS` function) sidesteps that.
+import filterXSS from 'xss'
+
+// Allowlist for rich-text article bodies authored via the Tiptap editor in
+// ArticleManagementView. This is the authoritative sanitization step: it runs
+// on every article create/update so stored content can never contain script
+// tags, event handlers, or other unexpected markup — regardless of whether a
+// request came from the editor UI or a direct API call.
+const ARTICLE_BODY_XSS_OPTIONS = {
+  whiteList: {
+    p: [],
+    br: [],
+    strong: [],
+    em: [],
+    u: [],
+    s: [],
+    h2: [],
+    h3: [],
+    ul: [],
+    ol: [],
+    li: [],
+    blockquote: [],
+    a: ['href', 'target', 'rel'],
+    img: ['src', 'alt', 'width', 'height'],
+  },
+  // Unwrap any tag not in the allowlist but keep its text content (friendlier
+  // for pasted content), EXCEPT for script/style tags, whose body is dropped
+  // along with the tag itself since their "text content" is code, not prose.
+  stripIgnoreTag: true,
+  stripIgnoreTagBody: ['script', 'style'],
+  css: false,
+}
+
+/** Sanitizes an article body's HTML before it is persisted to D1. */
+export function sanitizeArticleBody(html: string): string {
+  return filterXSS(html, ARTICLE_BODY_XSS_OPTIONS)
+}

--- a/worker/src/routes/articles.ts
+++ b/worker/src/routes/articles.ts
@@ -3,6 +3,7 @@ import { drizzle } from 'drizzle-orm/d1'
 import { asc, and, eq, ne } from 'drizzle-orm'
 import { articleCategories, articles } from '../db/schema'
 import { requireRole } from '../middleware/auth'
+import { sanitizeArticleBody } from '../lib/sanitize-html'
 import type { HonoEnv } from '../types'
 import type { DB } from '../lib/reshape'
 
@@ -78,7 +79,7 @@ articleRoutes.post('/articles', requireRole('admin', 'editor'), async (c) => {
     categoryId,
     title,
     summary,
-    body: content,
+    body: sanitizeArticleBody(content),
     status,
     displayOrder: body.displayOrder ?? 0,
     publishedAt: status === 'published' ? new Date().toISOString() : null,
@@ -147,7 +148,7 @@ articleRoutes.put('/articles/:id', requireRole('admin', 'editor'), async (c) => 
   if (body.body !== undefined) {
     const content = body.body.trim()
     if (!content) return c.json({ error: 'Nội dung không được để trống' }, 400)
-    updates.body = content
+    updates.body = sanitizeArticleBody(content)
   }
 
   if (body.status !== undefined) updates.status = body.status
@@ -202,6 +203,25 @@ articleRoutes.post('/articles/:id/cover', requireRole('admin', 'editor'), async 
 
   const row = await db.select().from(articles).where(eq(articles.id, id)).get()
   return c.json(row!)
+})
+
+// Uploads an image to embed inline within an article's rich-text body (via the
+// Tiptap editor's image button). Unlike the cover endpoint above, this isn't
+// tied to a specific article id — an article may embed any number of these
+// images, and the editor needs to upload images while composing a brand new
+// (not-yet-saved) article too.
+articleRoutes.post('/article-images', requireRole('admin', 'editor'), async (c) => {
+  const formData = await c.req.formData()
+  const file = formData.get('file') as File | null
+  if (!file) return c.json({ error: 'Thiếu tệp ảnh' }, 400)
+
+  const ext = file.name.split('.').pop() ?? 'jpg'
+  const key = `article-content/${crypto.randomUUID()}.${ext}`
+  await c.env.giapha_avatars.put(key, await file.arrayBuffer(), {
+    httpMetadata: { contentType: file.type },
+  })
+
+  return c.json({ url: `/api/avatars/${key}` }, 201)
 })
 
 export default articleRoutes

--- a/worker/test/routes-articles.test.ts
+++ b/worker/test/routes-articles.test.ts
@@ -239,6 +239,27 @@ describe('POST /api/articles', () => {
     expect(res.status).toBe(400)
     expect(await res.json()).toEqual({ error: 'Trạng thái bài viết không hợp lệ' })
   })
+
+  it('sanitizes the rich-text body, keeping safe formatting but stripping scripts and event handlers', async () => {
+    const app = buildApp()
+    const { token } = await makeUser('admin')
+
+    const res = await app.request('/api/articles', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Cookie: `${SESSION_COOKIE_NAME}=${token}` },
+      body: JSON.stringify({
+        slug: `sanitize-${crypto.randomUUID()}`,
+        categoryId: 'cat-gioi-thieu',
+        title: 'Bài viết định dạng',
+        summary: 'Tóm tắt',
+        body: '<p>Xin <strong>chào</strong> <img src="/api/avatars/x.jpg" onerror="alert(1)"></p><script>alert(2)</script>',
+      }),
+    }, env)
+
+    expect(res.status).toBe(201)
+    const created = await res.json<{ body: string }>()
+    expect(created.body).toBe('<p>Xin <strong>chào</strong> <img src="/api/avatars/x.jpg"></p>')
+  })
 })
 
 describe('PUT /api/articles/:id', () => {
@@ -342,6 +363,22 @@ describe('PUT /api/articles/:id', () => {
     expect(res.status).toBe(400)
     expect(await res.json()).toEqual({ error: 'Trạng thái bài viết không hợp lệ' })
   })
+
+  it('sanitizes the rich-text body on update as well', async () => {
+    const app = buildApp()
+    const { token } = await makeUser('editor')
+    const article = await createArticle(app, token, { slug: `sanitize-update-${crypto.randomUUID()}` })
+
+    const res = await app.request(`/api/articles/${article.id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json', Cookie: `${SESSION_COOKIE_NAME}=${token}` },
+      body: JSON.stringify({ body: '<h2 onclick="steal()">Tiêu đề phụ</h2><iframe src="evil.com"></iframe>' }),
+    }, env)
+
+    expect(res.status).toBe(200)
+    const updated = await res.json<{ body: string }>()
+    expect(updated.body).toBe('<h2>Tiêu đề phụ</h2>')
+  })
 })
 
 describe('DELETE /api/articles/:id', () => {
@@ -394,5 +431,49 @@ describe('POST /api/articles/:id/cover', () => {
     const body = await res.json<{ id: string; coverImageKey: string | null }>()
     expect(body.id).toBe(article.id)
     expect(body.coverImageKey).toBe(`article-covers/${article.id}.png`)
+  })
+})
+
+describe('POST /api/article-images', () => {
+  it('returns 401 without auth', async () => {
+    const app = buildApp()
+
+    const res = await app.request('/api/article-images', { method: 'POST', body: new FormData() }, env)
+
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 400 when no file is provided', async () => {
+    const app = buildApp()
+    const { token } = await makeUser('editor')
+
+    const res = await app.request('/api/article-images', {
+      method: 'POST',
+      headers: { Cookie: `${SESSION_COOKIE_NAME}=${token}` },
+      body: new FormData(),
+    }, env)
+
+    expect(res.status).toBe(400)
+    expect(await res.json()).toEqual({ error: 'Thiếu tệp ảnh' })
+  })
+
+  it('uploads an inline content image and returns a fetchable url, without requiring an existing article', async () => {
+    const app = buildApp()
+    const { token } = await makeUser('editor')
+    const formData = new FormData()
+    formData.set('file', new File([new Blob(['hello inline image'])], 'photo.jpg', { type: 'image/jpeg' }))
+
+    const res = await app.request('/api/article-images', {
+      method: 'POST',
+      headers: { Cookie: `${SESSION_COOKIE_NAME}=${token}` },
+      body: formData,
+    }, env)
+
+    expect(res.status).toBe(201)
+    const body = await res.json<{ url: string }>()
+    expect(body.url).toMatch(/^\/api\/avatars\/article-content\/[0-9a-f-]+\.jpg$/)
+
+    const stored = await env.giapha_avatars.get(body.url.replace('/api/avatars/', ''))
+    expect(await stored?.text()).toBe('hello inline image')
   })
 })


### PR DESCRIPTION
## Summary
Implements a rich-text editor (Tiptap) for the article "Nội dung" field in the Control Panel, replacing the plain textarea, so published articles can have proper formatting including inline images.

## Changes
- **Server-side sanitization** (`worker/src/lib/sanitize-html.ts`): authoritative HTML allowlist sanitizer (via `xss` package) applied on every article create/update. Allows `p, br, strong, em, u, s, h2, h3, ul, ol, li, blockquote, a[href,target,rel], img[src,alt,width,height]`; strips everything else (scripts/styles dropped entirely, other disallowed tags unwrapped but text kept).
- **New endpoint** `POST /api/article-images`: standalone inline-image upload, not tied to an article id (unlike the existing cover-image endpoint), so images can be added while composing a new, unsaved article. Stores to R2 under `article-content/<uuid>.<ext>`.
- **`RichTextEditor` component** (`src/components/RichTextEditor.tsx`): Tiptap-based editor with a toolbar (bold, italic, underline, strike, H2/H3, bullet/ordered lists, blockquote, link, image), wired into both the create and edit article forms in `ArticleManagementView.tsx`.
- **Landing page rendering**: article body is now rendered via `dangerouslySetInnerHTML` (safe since it's sanitized server-side) instead of plain-text paragraph splitting. Reading-time estimate now strips HTML tags before counting words. Added CSS for headings/lists/blockquote/links/images matching the existing article style.
- **Tests**: new `RichTextEditor.test.tsx` (renders content, toolbar, image upload flow), updated `ArticleManagementView.test.tsx` (mocks `RichTextEditor` with a plain textarea stub, since Tiptap/ProseMirror needs real browser contenteditable APIs not available in jsdom), new worker tests for sanitization (create/update) and the new image upload endpoint.

## Verification
- `npx tsc --noEmit` — no errors
- Full frontend suite: `npx vitest run src` — 252/252 passed
- Worker `routes-articles` suite: 23/23 passed (a pre-existing, unrelated `routes-persons.test.ts` FK-constraint flake exists on `master` too, confirmed by running that file alone)
- `npm run build` — succeeds
- `npx eslint` on all touched files — no new errors (pre-existing errors in untouched files/lines only)

No DB schema changes — `articles.body` stays `TEXT`; only its semantic content changes from plain text to sanitized HTML. Production currently has 0 articles, so there's no legacy-content migration concern.
