### PR TITLE
style(gia-pha): restyle /gia-pha to match landing page sepia theme

### DIFF
--- a/src/components/BottomTabBar.tsx
+++ b/src/components/BottomTabBar.tsx
@@ -18,7 +18,7 @@ export default function BottomTabBar({ onAddClick }: Props) {
         onClick={() => setViewMode('tree')}
         aria-current={viewMode === 'tree' ? 'page' : undefined}
         className={`flex-1 flex flex-col items-center gap-0.5 py-2 text-xs ${
-          viewMode === 'tree' ? 'text-blue-600 font-semibold' : 'text-muted'
+          viewMode === 'tree' ? 'text-accent font-semibold' : 'text-muted'
         }`}
       >
         <span aria-hidden="true">🌳</span>
@@ -29,7 +29,7 @@ export default function BottomTabBar({ onAddClick }: Props) {
         onClick={() => setViewMode('list')}
         aria-current={viewMode === 'list' ? 'page' : undefined}
         className={`flex-1 flex flex-col items-center gap-0.5 py-2 text-xs ${
-          viewMode === 'list' ? 'text-blue-600 font-semibold' : 'text-muted'
+          viewMode === 'list' ? 'text-accent font-semibold' : 'text-muted'
         }`}
       >
         <span aria-hidden="true">📋</span>

--- a/src/components/ListView.test.tsx
+++ b/src/components/ListView.test.tsx
@@ -117,21 +117,21 @@ describe('ListView spouse rendering', () => {
 
     // 'Bà Thanh' (female, laThanhVienHo: false) — married-in wife, dimmed.
     const thanh = screen.getByText('Bà Thanh')
-    expect(thanh.className).toContain('text-gray-400')
+    expect(thanh.className).toContain('text-muted')
 
     // 'Khánh' (male, laThanhVienHo: false) — married-in husband, must dim the same way.
     const khanh = screen.getByText('Khánh')
-    expect(khanh.className).toContain('text-gray-400')
+    expect(khanh.className).toContain('text-muted')
 
     // 'Phúc' (male, laThanhVienHo: false, blood descendant through non-clan father) also dims.
     const phuc = screen.getByText('Phúc')
-    expect(phuc.className).toContain('text-gray-400')
+    expect(phuc.className).toContain('text-muted')
 
     // Actual clan members (regardless of gender) stay un-dimmed.
     const vinh = screen.getByText('Vinh')
-    expect(vinh.className).toContain('text-gray-900')
+    expect(vinh.className).toContain('text-ink')
     const nga = screen.getByText('Nga')
-    expect(nga.className).toContain('text-gray-900')
+    expect(nga.className).toContain('text-ink')
   })
 
   it('groups each spouse with only their own children, in marriage order', () => {

--- a/src/components/ListView.tsx
+++ b/src/components/ListView.tsx
@@ -62,27 +62,27 @@ function PersonRow({
       <div
         data-person-id={person.id}
         className={`flex items-center gap-2 py-1.5 px-2 cursor-pointer rounded transition-colors
-          ${isSelected ? 'bg-blue-100' : ''}
-          ${isHighlighted && !isSelected ? 'ring-2 ring-blue-400' : ''}
-          hover:bg-gray-50`}
+          ${isSelected ? 'bg-accent-soft' : ''}
+          ${isHighlighted && !isSelected ? 'ring-2 ring-highlight' : ''}
+          hover:bg-card-hover`}
         style={{ paddingLeft: `${depth * 20 + 8}px` }}
         onClick={() => onSelect(person.id)}
       >
-        <span className={`w-2 h-2 rounded-full flex-shrink-0 ${isClan ? 'bg-blue-500' : 'bg-gray-300'}`} />
+        <span className={`w-2 h-2 rounded-full flex-shrink-0 ${isClan ? 'bg-accent' : 'bg-card-border'}`} />
         {isSpouse && (
-          <span aria-label="Vợ/chồng" className="text-xs text-amber-500">💍</span>
+          <span aria-label="Vợ/chồng" className="text-xs text-highlight">💍</span>
         )}
         {person.pendingRequestId && user && (
-          <span aria-label="Đang chờ duyệt" title="Đang chờ duyệt" className="text-xs text-amber-600">⏳</span>
+          <span aria-label="Đang chờ duyệt" title="Đang chờ duyệt" className="text-xs text-highlight">⏳</span>
         )}
-        <span className={`text-sm ${isClan ? 'text-gray-900' : 'text-gray-400'}`}>
+        <span className={`text-sm ${isClan ? 'text-ink' : 'text-muted'}`}>
           {dinhDangTenNguoi(person, showGenerationOrder)}
         </span>
         {person.namSinh?.nam && (
-          <span className="text-xs text-gray-400">({person.namSinh.nam})</span>
+          <span className="text-xs text-muted">({person.namSinh.nam})</span>
         )}
         {person.namMat && (
-          <span className="text-xs text-gray-300 ml-auto">†</span>
+          <span className="text-xs text-muted ml-auto">†</span>
         )}
       </div>
       {!hideChildren && (
@@ -134,20 +134,20 @@ export default function ListView() {
     row?.scrollIntoView({ behavior: 'smooth', block: 'center' })
   }, [highlightedPersonId])
 
-  if (!data) return <div className="p-4 text-gray-400">Chưa có dữ liệu</div>
+  if (!data) return <div className="p-4 text-muted">Chưa có dữ liệu</div>
 
   const roots = Object.values(data.persons).filter(p => p.laThanhVienHo && (!p.boId || !data.persons[p.boId]))
   const sortedRoots = sapXepAnhChiEm(roots)
 
   return (
-    <div ref={containerRef} className="flex-1 overflow-y-auto bg-white p-2 touch-pan-y">
+    <div ref={containerRef} className="flex-1 overflow-y-auto bg-canvas p-2 touch-pan-y">
       {sortedRoots.map(root => (
         <PersonRow key={root.id} person={root} depth={0}
           onSelect={selectPerson} selectedId={selectedPersonId} highlightId={highlightedPersonId}
           showGenerationOrder={hienThiThuTuDoi} />
       ))}
       {sortedRoots.length === 0 && (
-        <p className="text-center text-gray-400 py-8">Chưa có người nào. Hãy thêm người đầu tiên.</p>
+        <p className="text-center text-muted py-8">Chưa có người nào. Hãy thêm người đầu tiên.</p>
       )}
     </div>
   )

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -5,6 +5,7 @@ import { useAuthStore } from '../store/useAuthStore'
 import SearchBar from './SearchBar'
 import LoginModal from './LoginModal'
 import { useIsMobile } from '../utils/useIsMobile'
+import '../styles/gia-pha-theme.css'
 
 const ROLE_LABELS: Record<string, string> = { admin: 'Admin', editor: 'Editor', viewer: 'Viewer' }
 
@@ -28,38 +29,44 @@ export default function Navbar() {
 
   return (
     <>
-    <nav className="relative bg-card border-b border-card-border flex flex-col">
-      <div className="px-4 py-2 flex items-center gap-4">
+    <nav className="gp-header relative flex flex-col">
+      <div className="gp-header-inner">
         <button
           type="button"
           aria-label="Mở menu"
           aria-expanded={menuOpen}
           onClick={() => setMenuOpen(v => !v)}
-          className="px-2 py-1.5 text-lg leading-none text-muted rounded-md border border-card-border hover:bg-slate-50"
+          className="gp-seal-button"
         >
-          ☰
+          黃
         </button>
-        <div className="min-w-0">
-          <h1 className="text-lg font-bold text-ink whitespace-nowrap">
-            {data?.metadata.tenDongHo || 'Gia phả họ Hoàng'}
-          </h1>
-        </div>
+        <a href="/" className="gp-brand min-w-0">
+          <strong>{data?.metadata.tenDongHo || 'Gia phả họ Hoàng'}</strong>
+        </a>
 
-        {!isMobile && <SearchBar />}
+        {!isMobile && <SearchBar className="gp-search" />}
 
-        {user && (
-          <div className="ml-auto flex items-center gap-2 shrink-0">
-            <span className="text-sm text-ink font-medium hidden sm:inline">{user.username}</span>
-            <span className="px-2 py-0.5 text-xs font-medium rounded-full bg-blue-100 text-blue-700">
+        {user ? (
+          <div className="gp-user-badge">
+            <span className="text-sm font-medium hidden sm:inline">{user.username}</span>
+            <span className="gp-role-pill">
               {ROLE_LABELS[user.role] ?? user.role}
             </span>
           </div>
+        ) : (
+          <button
+            type="button"
+            onClick={() => setLoginModalOpen(true)}
+            className="gp-login-link ml-auto"
+          >
+            Đăng nhập
+          </button>
         )}
       </div>
 
       {isMobile && (
-        <div data-testid="navbar-search-row-mobile" className="px-4 pb-2">
-          <SearchBar />
+        <div data-testid="navbar-search-row-mobile" className="gp-search-row">
+          <SearchBar className="gp-search" />
         </div>
       )}
 
@@ -68,28 +75,28 @@ export default function Navbar() {
           <div
             aria-hidden="true"
             onClick={() => setMenuOpen(false)}
-            className="fixed inset-0 z-30"
+            className="gp-dropdown-backdrop"
           />
-          <div className="absolute top-full left-4 mt-2 z-40 w-72 bg-card border border-card-border rounded-lg shadow-lg p-3 space-y-2">
-            <div>
-              <label htmlFor="navbar-view-mode" className="block text-xs text-muted mb-1">Chế độ xem</label>
+          <div className="gp-dropdown">
+            <div className="px-2 pt-1 pb-2">
+              <label htmlFor="navbar-view-mode" className="block text-xs text-[#d5c9b6] mb-1">Chế độ xem</label>
               <select
                 id="navbar-view-mode"
                 aria-label="Chế độ xem"
                 value={selectableViewMode}
                 onChange={e => setViewMode(e.target.value as 'tree' | 'list')}
-                className="w-full px-2 py-1.5 text-sm border border-card-border rounded-md bg-card"
+                className="w-full px-2 py-1.5 text-sm rounded-md border border-white/20 bg-white/10 text-inherit"
               >
-                <option value="" disabled>Chế độ xem</option>
-                <option value="tree">Cây</option>
-                <option value="list">Danh sách</option>
+                <option value="" disabled className="text-ink">Chế độ xem</option>
+                <option value="tree" className="text-ink">Cây</option>
+                <option value="list" className="text-ink">Danh sách</option>
               </select>
             </div>
 
             <Link
               to="/"
               onClick={() => setMenuOpen(false)}
-              className="block w-full px-3 py-1.5 text-sm rounded-md border border-card-border hover:bg-slate-50 text-left"
+              className="gp-dropdown-item"
             >
               Trang chủ
             </Link>
@@ -98,7 +105,7 @@ export default function Navbar() {
               <Link
                 to="/control-panel"
                 onClick={() => setMenuOpen(false)}
-                className="block w-full px-3 py-1.5 text-sm rounded-md border border-card-border hover:bg-slate-50 text-left"
+                className="gp-dropdown-item"
               >
                 Quản lý
               </Link>
@@ -109,31 +116,24 @@ export default function Navbar() {
                 toggleGenerationOrder()
                 setMenuOpen(false)
               }}
-              className="w-full px-3 py-1.5 text-sm rounded-md border border-card-border hover:bg-slate-50 text-left"
+              className="gp-dropdown-item"
             >
               Thứ tự đời: {hienThiThuTuDoi ? 'Bật' : 'Tắt'}
             </button>
 
-            {user ? (
-              <button
-                onClick={() => {
-                  logout()
-                  setMenuOpen(false)
-                }}
-                className="w-full px-3 py-1.5 text-sm rounded-md border border-card-border hover:bg-slate-50 text-left"
-              >
-                Đăng xuất
-              </button>
-            ) : (
-              <button
-                onClick={() => {
-                  setLoginModalOpen(true)
-                  setMenuOpen(false)
-                }}
-                className="w-full px-3 py-1.5 text-sm rounded-md border border-card-border hover:bg-slate-50 text-left"
-              >
-                Đăng nhập
-              </button>
+            {user && (
+              <>
+                <div className="gp-dropdown-divider" />
+                <button
+                  onClick={() => {
+                    logout()
+                    setMenuOpen(false)
+                  }}
+                  className="gp-dropdown-item"
+                >
+                  Đăng xuất
+                </button>
+              </>
             )}
           </div>
         </>

--- a/src/components/PersonCard.tsx
+++ b/src/components/PersonCard.tsx
@@ -33,7 +33,7 @@ export default function PersonCard({ person, displayName, isSelected, isHighligh
         relative w-full h-full rounded-xl border p-2 cursor-pointer text-left
         ${isSpouse ? 'bg-card-spouse' : 'bg-card'} shadow-sm transition-all hover:shadow-md hover:-translate-y-px
         ${isSelected ? 'outline outline-2 outline-accent outline-offset-1 bg-accent-soft border-accent-soft' : 'border-card-border'}
-        ${isHighlighted && !isSelected ? 'ring-2 ring-blue-400' : ''}
+        ${isHighlighted && !isSelected ? 'ring-2 ring-highlight' : ''}
       `}
     >
       {isMarriedIn && (
@@ -72,7 +72,7 @@ export default function PersonCard({ person, displayName, isSelected, isHighligh
             person.namSinh?.nam ? String(person.namSinh.nam) : null,
           ].filter(Boolean).join('/')}
           {person.namSinh?.amLich && <span className="ml-0.5 text-amber-600">ÂL</span>}
-          {person.namMat && <span className="ml-1 text-slate-400">†</span>}
+          {person.namMat && <span className="ml-1 text-muted">†</span>}
         </div>
       )}
     </div>

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -4,7 +4,11 @@ import { useGiaphaStore } from '../store/useGiaphaStore'
 import SearchResults from './SearchResults'
 import type { Person } from '../types/giapha'
 
-export default function SearchBar() {
+interface Props {
+  className?: string
+}
+
+export default function SearchBar({ className }: Props) {
   const data = useGiaphaStore(s => s.data)
   const focusPerson = useGiaphaStore(s => s.focusPerson)
   const [query, setQuery] = useState('')
@@ -43,7 +47,7 @@ export default function SearchBar() {
         value={query}
         onChange={handleChange}
         placeholder="Tìm kiếm theo tên..."
-        className="w-full px-3 py-1.5 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-400"
+        className={className ? className : 'w-full px-3 py-1.5 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-400'}
       />
       {open && <SearchResults results={results} onSelect={id => { focusPerson(id); setQuery(''); setOpen(false) }} />}
     </div>

--- a/src/components/SearchResults.tsx
+++ b/src/components/SearchResults.tsx
@@ -11,15 +11,15 @@ export default function SearchResults({ results, onSelect }: Props) {
   const showGenerationOrder = useGiaphaStore(s => s.hienThiThuTuDoi)
 
   return (
-    <ul className="absolute top-full left-0 right-0 mt-1 bg-white border border-gray-200 rounded-md shadow-lg z-50 max-h-60 overflow-y-auto">
+    <ul className="gp-search-results absolute top-full left-0 right-0 mt-1 z-50 max-h-60 overflow-y-auto">
       {results.map(p => (
         <li
           key={p.id}
-          className="px-3 py-2 hover:bg-blue-50 cursor-pointer text-sm"
+          className="gp-search-results-item px-3 py-2 cursor-pointer text-sm"
           onClick={() => onSelect(p.id)}
         >
           <span className="font-medium">{dinhDangTenNguoi(p, showGenerationOrder)}</span>
-          {p.namSinh?.nam && <span className="text-gray-400 ml-2">({p.namSinh.nam})</span>}
+          {p.namSinh?.nam && <span className="text-muted ml-2">({p.namSinh.nam})</span>}
         </li>
       ))}
     </ul>

--- a/src/components/TreeView.test.tsx
+++ b/src/components/TreeView.test.tsx
@@ -190,8 +190,8 @@ describe('TreeView', () => {
     const svgLines = container.querySelectorAll('svg line')
 
     expect(svgLines.length).toBeGreaterThan(0)
-    expect(container.querySelector('svg line[stroke="#7C3AED"][stroke-width="3"]')).not.toBeNull()
-    expect(container.querySelector('svg line[stroke="#0F172A"][stroke-width="3"]')).not.toBeNull()
+    expect(container.querySelector('svg line[stroke="#8e342b"][stroke-width="3"]')).not.toBeNull()
+    expect(container.querySelector('svg line[stroke="#4a2c24"][stroke-width="3"]')).not.toBeNull()
     expect(container.querySelector('svg line[stroke="#CBD5E1"]')).toBeNull()
   })
 

--- a/src/components/TreeView.tsx
+++ b/src/components/TreeView.tsx
@@ -21,8 +21,8 @@ const NAME_CHAR_WIDTH_ESTIMATE = 8
 const NAME_TEXT_STYLE = '600 12px sans-serif'
 const AVATAR_DIAMETER = 24  // reserved width for PersonCard's avatar circle
 const AVATAR_GAP = 8        // gap between avatar and name text
-const COUPLE_LINE_COLOR = '#7C3AED'
-const DESCENT_LINE_COLOR = '#0F172A'
+const COUPLE_LINE_COLOR = '#8e342b'
+const DESCENT_LINE_COLOR = '#4a2c24'
 const LINE_STROKE_WIDTH = 3
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -684,7 +684,7 @@ export default function TreeView() {
     pinchStateRef.current.pinching = false
   }, [])
 
-  if (!data) return <div className="flex-1 flex items-center justify-center text-gray-400">Chưa có dữ liệu</div>
+  if (!data) return <div className="flex-1 flex items-center justify-center text-muted">Chưa có dữ liệu</div>
 
   return (
     <div className="relative flex-1 overflow-hidden">
@@ -760,7 +760,7 @@ export default function TreeView() {
               aria-label={t.collapsed ? 'Mở rộng nhánh con' : 'Thu gọn nhánh con'}
               onClick={(e) => { e.stopPropagation(); toggleCollapse(t.personId) }}
               style={{ position: 'absolute', left: t.x - 12, top: t.y - 10, zIndex: 2 }}
-              className="h-5 min-w-5 px-1 rounded-full border border-card-border bg-card text-[10px] font-semibold text-muted leading-5 text-center shadow-sm hover:bg-slate-50"
+              className="h-5 min-w-5 px-1 rounded-full border border-card-border bg-card text-[10px] font-semibold text-muted leading-5 text-center shadow-sm hover:bg-card-hover"
             >
               {t.collapsed ? `+${t.hiddenCount}` : '−'}
             </button>
@@ -775,7 +775,7 @@ export default function TreeView() {
           onClick={zoomOut}
           disabled={zoom <= MIN_ZOOM}
           aria-label="Thu nhỏ cây"
-          className="h-11 w-11 sm:h-8 sm:w-8 rounded border border-card-border text-muted text-lg leading-none hover:bg-slate-50 disabled:opacity-50"
+          className="h-11 w-11 sm:h-8 sm:w-8 rounded border border-card-border text-muted text-lg leading-none hover:bg-card-hover disabled:opacity-50"
         >
           −
         </button>
@@ -783,7 +783,7 @@ export default function TreeView() {
           type="button"
           onClick={resetZoom}
           aria-label="Đặt lại mức thu phóng"
-          className="rounded border border-card-border text-muted px-2 py-1 text-xs font-medium hover:bg-slate-50"
+          className="rounded border border-card-border text-muted px-2 py-1 text-xs font-medium hover:bg-card-hover"
         >
           {Math.round(zoom * 100)}%
         </button>
@@ -792,7 +792,7 @@ export default function TreeView() {
           onClick={zoomIn}
           disabled={zoom >= MAX_ZOOM}
           aria-label="Phóng to cây"
-          className="h-11 w-11 sm:h-8 sm:w-8 rounded border border-card-border text-muted text-lg leading-none hover:bg-slate-50 disabled:opacity-50"
+          className="h-11 w-11 sm:h-8 sm:w-8 rounded border border-card-border text-muted text-lg leading-none hover:bg-card-hover disabled:opacity-50"
         >
           +
         </button>

--- a/src/components/ViewToggle.test.tsx
+++ b/src/components/ViewToggle.test.tsx
@@ -1,0 +1,32 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import ViewToggle from './ViewToggle'
+import { useGiaphaStore } from '../store/useGiaphaStore'
+
+describe('ViewToggle', () => {
+  beforeEach(() => {
+    useGiaphaStore.setState({ viewMode: 'tree' })
+  })
+
+  it('marks the current view mode as the selected tab', () => {
+    render(<ViewToggle />)
+    expect(screen.getByRole('tab', { name: 'Cây gia phả' })).toHaveAttribute('aria-selected', 'true')
+    expect(screen.getByRole('tab', { name: 'Danh sách' })).toHaveAttribute('aria-selected', 'false')
+  })
+
+  it('switches to list view when the "Danh sách" tab is clicked', async () => {
+    const user = userEvent.setup()
+    render(<ViewToggle />)
+    await user.click(screen.getByRole('tab', { name: 'Danh sách' }))
+    expect(useGiaphaStore.getState().viewMode).toBe('list')
+  })
+
+  it('switches back to tree view when the "Cây gia phả" tab is clicked', async () => {
+    useGiaphaStore.setState({ viewMode: 'list' })
+    const user = userEvent.setup()
+    render(<ViewToggle />)
+    await user.click(screen.getByRole('tab', { name: 'Cây gia phả' }))
+    expect(useGiaphaStore.getState().viewMode).toBe('tree')
+  })
+})

--- a/src/components/ViewToggle.tsx
+++ b/src/components/ViewToggle.tsx
@@ -1,0 +1,34 @@
+import { useGiaphaStore } from '../store/useGiaphaStore'
+
+/**
+ * Prominent pill-tab switch between "Cây gia phả" and "Danh sách", shown in
+ * the content area on desktop (mirrors the approved gia-pha mockup). On
+ * mobile the same switching is already handled by BottomTabBar, so this is
+ * not rendered there to avoid two redundant controls on a small screen.
+ */
+export default function ViewToggle() {
+  const { viewMode, setViewMode } = useGiaphaStore()
+
+  return (
+    <div className="gp-view-toggle" role="tablist" aria-label="Chọn chế độ xem">
+      <button
+        type="button"
+        role="tab"
+        aria-selected={viewMode === 'tree'}
+        onClick={() => setViewMode('tree')}
+        className={`gp-view-toggle-btn ${viewMode === 'tree' ? 'is-active' : ''}`}
+      >
+        Cây gia phả
+      </button>
+      <button
+        type="button"
+        role="tab"
+        aria-selected={viewMode === 'list'}
+        onClick={() => setViewMode('list')}
+        className={`gp-view-toggle-btn ${viewMode === 'list' ? 'is-active' : ''}`}
+      >
+        Danh sách
+      </button>
+    </div>
+  )
+}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -6,9 +6,11 @@ import PersonForm from '../components/PersonForm'
 import PersonDetailPanel from '../components/PersonDetailPanel'
 import CyclicRelationshipBanner from '../components/CyclicRelationshipBanner'
 import BottomTabBar from '../components/BottomTabBar'
+import ViewToggle from '../components/ViewToggle'
 import { useGiaphaStore } from '../store/useGiaphaStore'
 import { useAuthStore } from '../store/useAuthStore'
 import { useIsMobile } from '../utils/useIsMobile'
+import '../styles/gia-pha-theme.css'
 
 export default function HomePage() {
   const { viewMode, data, selectedPersonId, selectPerson } = useGiaphaStore()
@@ -35,9 +37,15 @@ export default function HomePage() {
   }
 
   return (
-    <div className="h-dvh flex flex-col overflow-hidden">
+    <div className="gp-shell h-dvh flex flex-col overflow-hidden">
       <Navbar />
       <CyclicRelationshipBanner />
+
+      {!isMobile && (
+        <div className="px-4 py-3">
+          <ViewToggle />
+        </div>
+      )}
 
       <div className="flex flex-1 overflow-hidden">
         {viewMode === 'tree' && <TreeView />}
@@ -49,7 +57,7 @@ export default function HomePage() {
       {canEdit && (
         <button
           onClick={openAdd}
-          className="hidden sm:flex fixed bottom-6 right-6 w-12 h-12 bg-blue-600 text-white rounded-full shadow-lg hover:bg-blue-700 text-2xl items-center justify-center z-30"
+          className="hidden sm:flex fixed bottom-6 right-6 w-12 h-12 bg-[#e2b95e] text-[#4a2c24] rounded-full shadow-lg hover:bg-[#f0cb78] text-2xl items-center justify-center z-30"
           title="Thêm người mới"
         >
           +

--- a/src/styles/gia-pha-theme.css
+++ b/src/styles/gia-pha-theme.css
@@ -1,0 +1,233 @@
+/*
+ * Shared warm/sepia "editorial" visual identity for the /gia-pha app shell,
+ * reusing the same palette and header look as the landing page
+ * (src/pages/LandingPage.css) so the whole product feels like one thing
+ * instead of two. Deliberately duplicated (not shared/imported) from
+ * LandingPage.css rather than refactored into a common file, to avoid any
+ * risk of regressing the already-shipped, well-tested landing page while
+ * both surfaces evolve independently.
+ */
+.gp-shell {
+  --cream: #f5efdf;
+  --paper: #fbf7ec;
+  --ink: #2e281f;
+  --muted: #756c5e;
+  --brown: #4a2c24;
+  --brick: #8e342b;
+  --amber: #c18b2c;
+  --line: rgba(68, 49, 36, 0.18);
+  --header: 64px;
+
+  color: var(--ink);
+  background:
+    linear-gradient(90deg, rgba(74, 44, 36, 0.025) 1px, transparent 1px) 0 0 / 28px 28px,
+    var(--cream);
+  font-family: 'Be Vietnam Pro', sans-serif;
+}
+
+.gp-shell a {
+  color: inherit;
+}
+
+/* Header — mirrors .lp-header from the landing page. */
+.gp-header {
+  position: relative;
+  z-index: 40;
+  height: var(--header);
+  display: flex;
+  align-items: center;
+  color: #fff8e7;
+  background: rgba(74, 44, 36, 0.96);
+  backdrop-filter: blur(16px);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+  flex-shrink: 0;
+}
+.gp-header-inner {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  gap: 18px;
+  padding: 0 16px;
+  min-width: 0;
+}
+.gp-seal-button {
+  width: 40px;
+  aspect-ratio: 1;
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--amber);
+  color: #f5d797;
+  font: 600 1.1rem 'IBM Plex Serif', serif;
+  transform: rotate(-3deg);
+  flex-shrink: 0;
+  background: none;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+.gp-seal-button:hover,
+.gp-seal-button[aria-expanded='true'] {
+  background: rgba(255, 255, 255, 0.08);
+}
+.gp-brand {
+  display: block;
+  min-width: 0;
+  text-decoration: none;
+}
+.gp-brand strong {
+  display: block;
+  font: 600 0.95rem 'IBM Plex Serif', serif;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.gp-login-link {
+  color: #f5d797;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font: 500 0.78rem 'Be Vietnam Pro', sans-serif;
+  text-decoration: underline;
+  text-underline-offset: 4px;
+  padding: 0;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+.gp-home-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  min-height: 38px;
+  padding: 0 16px;
+  color: var(--brown);
+  background: #e2b95e;
+  border-radius: 4px;
+  text-decoration: none;
+  font-size: 0.75rem;
+  font-weight: 700;
+  flex-shrink: 0;
+  transition: 0.2s;
+}
+.gp-home-link:hover {
+  background: #f0cb78;
+}
+.gp-user-badge {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+  margin-left: auto;
+}
+.gp-role-pill {
+  padding: 2px 8px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  border-radius: 999px;
+  background: rgba(245, 215, 151, 0.18);
+  color: #f5d797;
+}
+
+/* Hamburger dropdown menu, opened from the seal. */
+.gp-dropdown-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 30;
+}
+.gp-dropdown {
+  position: absolute;
+  top: 100%;
+  left: 16px;
+  margin-top: 8px;
+  z-index: 40;
+  width: 260px;
+  max-width: calc(100vw - 32px);
+  background: rgba(74, 44, 36, 0.98);
+  color: #f5efdf;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 6px;
+  box-shadow: 0 16px 36px rgba(0, 0, 0, 0.28);
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.gp-dropdown-item {
+  display: block;
+  width: 100%;
+  padding: 9px 10px;
+  border-radius: 4px;
+  border: none;
+  background: none;
+  color: #f5efdf;
+  font-size: 0.85rem;
+  text-align: left;
+  text-decoration: none;
+  cursor: pointer;
+}
+.gp-dropdown-item:hover {
+  background: rgba(255, 255, 255, 0.08);
+}
+.gp-dropdown-divider {
+  height: 1px;
+  margin: 4px 2px;
+  background: rgba(255, 255, 255, 0.12);
+}
+
+/* Search input — light-on-dark variant for use inside .gp-header. */
+.gp-search {
+  width: 100%;
+  padding: 7px 12px;
+  font-size: 0.85rem;
+  color: #fff8e7;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 4px;
+}
+.gp-search::placeholder {
+  color: #d5c9b6;
+}
+.gp-search:focus {
+  outline: none;
+  border-color: var(--amber);
+}
+.gp-search-row {
+  padding: 8px 16px;
+  background: rgba(74, 44, 36, 0.96);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+  flex-shrink: 0;
+}
+.gp-search-results {
+  background: var(--paper);
+  color: var(--ink);
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.18);
+}
+.gp-search-results-item:hover {
+  background: #f1e6d0;
+}
+
+/* Cây gia phả / Danh sách pill-tab toggle, shown above the content area. */
+.gp-view-toggle {
+  display: inline-flex;
+  gap: 4px;
+  padding: 4px;
+  background: var(--paper);
+  border: 1px solid var(--line);
+  border-radius: 999px;
+}
+.gp-view-toggle-btn {
+  padding: 6px 16px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  border-radius: 999px;
+  border: none;
+  background: none;
+  color: var(--muted);
+  cursor: pointer;
+  white-space: nowrap;
+}
+.gp-view-toggle-btn.is-active {
+  background: var(--brick);
+  color: #fff8e7;
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -4,16 +4,20 @@ export default {
   theme: {
     extend: {
       colors: {
-        canvas: '#f8fafc',
-        card: '#ffffff',
-        'card-border': '#e2e8f0',
-        'card-spouse': '#f1f5f9',
-        ink: '#0f172a',
-        muted: '#64748b',
-        accent: '#4f46e5',
-        'accent-soft': '#eef2ff',
-        nam: '#0ea5e9',
-        nu: '#f43f5e',
+        // Warm sepia/editorial palette shared with the landing page (see
+        // src/styles/gia-pha-theme.css), so /gia-pha and / read as one product.
+        canvas: '#f3ead4',
+        card: '#fbf7ec',
+        'card-hover': '#f1e6d0',
+        'card-border': '#e3d5b8',
+        'card-spouse': '#efe2c8',
+        ink: '#2e281f',
+        muted: '#756c5e',
+        accent: '#8e342b',
+        'accent-soft': '#f3e2c7',
+        highlight: '#c18b2c',
+        nam: '#7a4a30',
+        nu: '#b5793f',
       },
     },
   },


### PR DESCRIPTION
style(gia-pha): restyle /gia-pha to match landing page sepia theme

Re-skins the family-tree app to visually match the landing page's
warm sepia/editorial aesthetic (dark header, seal icon, brick/amber
accents) instead of its previous indigo/slate Tailwind palette, per
the approved gia-pha web/mobile mockups.

- tailwind.config.ts: redefine canvas/card/card-border/card-spouse/
  ink/muted/accent/accent-soft/nam/nu tokens to sepia values, add
  card-hover and highlight tokens.
- Navbar: dark sepia header reusing the landing page's header look;
  the seal is now the hamburger-menu trigger; dropdown restyled
  dark/gold; anonymous "Dang nhap" moved to the header itself.
- New ViewToggle pill-tab component (Cay gia pha / Danh sach) shown
  above the content area on desktop; existing "Che do xem" select
  kept in the Navbar dropdown for redundancy/no test-contract change.
- ListView/PersonCard/BottomTabBar/TreeView: replace hardcoded blue/
  gray/indigo utility classes with the new sepia tokens; TreeView's
  node position-calculation logic (collect()/layout useMemo) is
  untouched, only line-color constants and hover styles changed.
- SearchBar/SearchResults: dark-header-compatible input variant and
  paper-toned results dropdown.
- New src/styles/gia-pha-theme.css: header/dropdown/search/pill-tab
  styles, intentionally duplicated (not shared) from LandingPage.css
  to avoid coupling risk to the already-shipped landing page.

Updated ListView.test.tsx/TreeView.test.tsx for the renamed color
classes/values; added ViewToggle.test.tsx. Full suite (255 tests),
tsc --noEmit, and vite build all pass.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
